### PR TITLE
feat(smart-vault-modules): ComposableExecutionModule (ERC-8211) for SmartVaults

### DIFF
--- a/packages/smart-vault-modules/foundry.toml
+++ b/packages/smart-vault-modules/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 auto_detect_solc = false
-gas_reports = ["AutoEarnModule"]
+gas_reports = ["AutoEarnModule", "ComposableExecutionModule"]
 optimizer = true
 optimizer_runs = 5_000_000
 out = "out"

--- a/packages/smart-vault-modules/package.json
+++ b/packages/smart-vault-modules/package.json
@@ -15,7 +15,9 @@
     "test:coverage": "forge coverage",
     "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage",
     "deploy:AutoEarnModule:test": "export DRY_RUN=true && source .env && FOUNDRY_PROFILE=optimized forge script script/AutoEarnModule.s.sol:AutoEarnModuleScript --account SPLITS_V2_DEPLOYER -vvvvv --rpc-url ",
-    "deploy:AutoEarnModule": "export DRY_RUN=false && source .env && FOUNDRY_PROFILE=optimized forge script script/AutoEarnModule.s.sol:AutoEarnModuleScript --account SPLITS_V2_DEPLOYER --broadcast --verify -vvvvv --rpc-url "
+    "deploy:AutoEarnModule": "export DRY_RUN=false && source .env && FOUNDRY_PROFILE=optimized forge script script/AutoEarnModule.s.sol:AutoEarnModuleScript --account SPLITS_V2_DEPLOYER --broadcast --verify -vvvvv --rpc-url ",
+    "deploy:ComposableExecutionModule:test": "export DRY_RUN=true && source .env && FOUNDRY_PROFILE=optimized forge script script/ComposableExecutionModule.s.sol:ComposableExecutionModuleScript --account SPLITS_V2_DEPLOYER -vvvvv --rpc-url ",
+    "deploy:ComposableExecutionModule": "export DRY_RUN=false && source .env && FOUNDRY_PROFILE=optimized forge script script/ComposableExecutionModule.s.sol:ComposableExecutionModuleScript --account SPLITS_V2_DEPLOYER --broadcast --verify -vvvvv --rpc-url "
   },
   "keywords": [],
   "author": "@splits",

--- a/packages/smart-vault-modules/script/ComposableExecutionModule.s.sol
+++ b/packages/smart-vault-modules/script/ComposableExecutionModule.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.23;
+
+import { ComposableExecutionModule } from "src/ComposableExecutionModule.sol";
+import { Storage } from "src/vendor/composability/Storage.sol";
+
+import { BaseScript } from "./Base.s.sol";
+
+contract ComposableExecutionModuleScript is BaseScript {
+    function run() public {
+        vm.startBroadcast();
+        address store = address(new Storage{ salt: keccak256("splits.composabilityStorage.v1") }());
+        address module =
+            address(new ComposableExecutionModule{ salt: keccak256("splits.composableExecutionModule.v1") }());
+        vm.stopBroadcast();
+
+        updateDeployment(store, "ComposabilityStorage");
+        updateDeployment(module, "ComposableExecutionModule");
+    }
+}

--- a/packages/smart-vault-modules/src/ComposableExecutionModule.sol
+++ b/packages/smart-vault-modules/src/ComposableExecutionModule.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.23;
+
+import { Call, ISmartVault } from "src/interfaces/ISmartVault.sol";
+import {
+    ComposableExecution,
+    Execution,
+    InputParam,
+    OutputParam
+} from "src/vendor/composability/ComposabilityDataTypes.sol";
+import { ComposableExecutionLib } from "src/vendor/composability/ComposableExecutionLib.sol";
+
+/**
+ * @title Composable Execution Module
+ * @custom:security-contract security@splits.org
+ * @author Splits (https://splits.org)
+ * @notice ERC-8211 smart batching executor for SmartVault accounts. Each batch entry resolves its parameters at
+ *         execution time (raw bytes, static calls, or live balances), validates them against inline constraints,
+ *         and executes through the calling vault. Entries execute strictly in order, so a later entry's fetchers
+ *         observe the effects of earlier entries.
+ * @dev The account to execute for is always `msg.sender`; there is no account parameter. The intended flow is a
+ *      signed user operation calling `vault.execute(module, executeComposable(...))`, so the module sees the vault
+ *      as `msg.sender` and loops back via `executeFromModule`, where the vault's `onlyModule` check applies. A
+ *      direct caller can therefore only ever execute for itself. The module is stateless and holds no assets, so
+ *      reentrancy by a malicious target only lets that target execute for itself.
+ */
+contract ComposableExecutionModule {
+    using ComposableExecutionLib for InputParam[];
+    using ComposableExecutionLib for OutputParam[];
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   EVENTS                                   */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice Emitted after a composable batch executes for an account.
+    /// @param account The SmartVault account the batch executed for.
+    /// @param executions The number of entries in the batch.
+    event ExecutedComposable(address indexed account, uint256 executions);
+
+    /* -------------------------------------------------------------------------- */
+    /*                          EXTERNAL/PUBLIC FUNCTIONS                         */
+    /* -------------------------------------------------------------------------- */
+
+    /**
+     * @notice Executes a composable batch for `msg.sender`.
+     * @dev Per entry: resolve inputs (validating constraints), execute via `executeFromModule` on the caller, then
+     *      capture outputs. An entry that resolves to `target == address(0)` is a predicate-only check and skips
+     *      execution. Any constraint failure or call revert aborts the entire batch atomically.
+     * @param executions_ The composable batch entries to execute in order.
+     */
+    function executeComposable(ComposableExecution[] calldata executions_) external {
+        uint256 length = executions_.length;
+
+        for (uint256 i; i < length; i++) {
+            ComposableExecution calldata execution = executions_[i];
+            Execution memory resolved = execution.inputParams.processInputs(execution.functionSig);
+
+            if (resolved.target != address(0)) {
+                ISmartVault(msg.sender)
+                    .executeFromModule(
+                        Call({ target: resolved.target, value: resolved.value, data: resolved.callData })
+                    );
+            }
+
+            execution.outputParams.processOutputs("", msg.sender);
+        }
+
+        emit ExecutedComposable(msg.sender, length);
+    }
+}

--- a/packages/smart-vault-modules/src/interfaces/ISmartVault.sol
+++ b/packages/smart-vault-modules/src/interfaces/ISmartVault.sol
@@ -13,6 +13,9 @@ interface ISmartVault {
     /// @notice Executes a batch of calls from an enabled module.
     function executeFromModule(Call[] calldata calls_) external;
 
+    /// @notice Executes a single call from an enabled module.
+    function executeFromModule(Call calldata call_) external;
+
     /// @notice Enables a module on the vault. Can only be called by the vault itself.
     function enableModule(address module_) external;
 

--- a/packages/smart-vault-modules/src/vendor/composability/ComposabilityDataTypes.sol
+++ b/packages/smart-vault-modules/src/vendor/composability/ComposabilityDataTypes.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// Vendored from bcnmy/composable-batch-erc (MIT) @ 71d43fead3b836ee9cb5cebeac4f96a68bf21dc3.
+// Modifications: added the `Execution` struct locally (upstream imports it from erc7579).
+
+/// @notice Where a resolved input routes within the composed call.
+enum InputParamType {
+    TARGET, // The target address
+    VALUE, // The value
+    CALL_DATA // The call data
+}
+
+/// @notice How an input parameter's value is fetched at execution time.
+enum InputParamFetcherType {
+    RAW_BYTES, // Already encoded bytes
+    STATIC_CALL, // Perform a static call
+    BALANCE // Get the balance of an address
+}
+
+/// @notice How an output value is fetched for capture.
+enum OutputParamFetcherType {
+    EXEC_RESULT, // The return of the execution call
+    STATIC_CALL // Call to some other function
+}
+
+/// @notice Predicate applied to a resolved value.
+enum ConstraintType {
+    EQ, // Equal to
+    GTE, // Greater than or equal to
+    LTE, // Less than or equal to
+    IN // In range
+}
+
+/// @notice Constraint for parameter validation. Constraint `i` validates 32-byte word `i` of the resolved value, so
+///         single-word values (balances, static reads) support exactly one constraint.
+struct Constraint {
+    ConstraintType constraintType;
+    bytes referenceData;
+}
+
+/// @notice A dynamically resolved input parameter.
+struct InputParam {
+    InputParamType paramType;
+    InputParamFetcherType fetcherType; // How to fetch the parameter
+    bytes paramData;
+    Constraint[] constraints;
+}
+
+/// @notice A captured output written to the Storage contract.
+struct OutputParam {
+    OutputParamFetcherType fetcherType; // How to fetch the parameter
+    bytes paramData;
+}
+
+/// @notice A single composable batch entry.
+struct ComposableExecution {
+    bytes4 functionSig;
+    InputParam[] inputParams;
+    OutputParam[] outputParams;
+}
+
+/// @notice A resolved call ready for execution.
+struct Execution {
+    address target;
+    uint256 value;
+    bytes callData;
+}

--- a/packages/smart-vault-modules/src/vendor/composability/ComposableExecutionLib.sol
+++ b/packages/smart-vault-modules/src/vendor/composability/ComposableExecutionLib.sol
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { IERC20 } from "src/interfaces/IERC20.sol";
+import {
+    Constraint,
+    ConstraintType,
+    Execution,
+    InputParam,
+    InputParamFetcherType,
+    InputParamType,
+    OutputParam,
+    OutputParamFetcherType
+} from "src/vendor/composability/ComposabilityDataTypes.sol";
+import { Storage } from "src/vendor/composability/Storage.sol";
+
+// Vendored from bcnmy/composable-batch-erc (MIT) @ 71d43fead3b836ee9cb5cebeac4f96a68bf21dc3.
+// Modifications:
+// - Imports: `Execution` comes from the local types file (upstream: erc7579) and `IERC20` from
+//   src/interfaces/IERC20.sol (upstream: OpenZeppelin).
+// - `require(cond, CustomError())` rewritten to `if (!cond) revert ...;` (that require form needs solc >= 0.8.26;
+//   this package pins 0.8.23).
+// - `EXEC_RESULT` output capture reverts with `ExecResultNotSupported`: SmartVault's `executeFromModule` discards
+//   return data, so the module has no execution result to parse. `STATIC_CALL` output capture covers the same use
+//   cases by reading post-call state.
+
+// Library for composable execution handling
+library ComposableExecutionLib {
+    error ConstraintNotMet(ConstraintType constraintType);
+    error Output_StaticCallFailed();
+    error InvalidParameterEncoding(string message);
+    error InvalidOutputParamFetcherType();
+    error ComposableExecutionFailed();
+    error InvalidConstraintType();
+    error InvalidSetOfInputParams(string message);
+    error ExecResultNotSupported();
+
+    // Process the input parameters and return the composed calldata
+    function processInputs(
+        InputParam[] calldata inputParams,
+        bytes4 functionSig
+    )
+        internal
+        view
+        returns (Execution memory)
+    {
+        address composedTarget;
+        uint256 composedValue;
+        bytes memory composedCalldata = abi.encodePacked(functionSig);
+        uint256 length = inputParams.length;
+
+        // Bit 0: TARGET param type set, Bit 1: VALUE param type set
+        uint256 paramTypeFlags = 0;
+        for (uint256 i; i < length; i++) {
+            bytes memory processedInput = processInput(inputParams[i]);
+            if (inputParams[i].paramType == InputParamType.TARGET) {
+                if (inputParams[i].fetcherType == InputParamFetcherType.BALANCE) {
+                    revert InvalidParameterEncoding("BALANCE fetcher type is not supported for TARGET param type");
+                }
+                // Check if TARGET has already been set (bit 0)
+                if (paramTypeFlags & 1 != 0) {
+                    revert InvalidSetOfInputParams("TARGET param type can only be set once");
+                }
+                paramTypeFlags |= 1; // Set bit 0
+                composedTarget = abi.decode(processedInput, (address));
+            } else if (inputParams[i].paramType == InputParamType.VALUE) {
+                // Check if VALUE has already been set (bit 1)
+                if (paramTypeFlags & 2 != 0) {
+                    revert InvalidSetOfInputParams("VALUE param type can only be set once");
+                }
+                paramTypeFlags |= 2; // Set bit 1
+                composedValue = abi.decode(processedInput, (uint256));
+            } else if (inputParams[i].paramType == InputParamType.CALL_DATA) {
+                composedCalldata = bytes.concat(composedCalldata, processedInput);
+            } else {
+                revert InvalidParameterEncoding("Invalid param type");
+            }
+        }
+        // if a param with TARGET type was not provided, it will be address(0)
+        // we don't restrict it since some calls may want to call address(0)
+        // if a param with VALUE type was not provided, it will be 0
+        // this is even more often case, as many calls happen with 0 value
+        return Execution({ target: composedTarget, value: composedValue, callData: composedCalldata });
+    }
+
+    // Process a single input parameter and return the composed calldata
+    function processInput(InputParam calldata param) internal view returns (bytes memory) {
+        if (param.fetcherType == InputParamFetcherType.RAW_BYTES) {
+            _validateConstraints(param.paramData, param.constraints);
+            return param.paramData;
+        } else if (param.fetcherType == InputParamFetcherType.STATIC_CALL) {
+            address contractAddr;
+            bytes calldata callData;
+            bytes calldata paramData = param.paramData;
+            // expect paramData to be abi.encode(address contractAddr, bytes callData)
+            assembly {
+                contractAddr := calldataload(paramData.offset)
+                let s := calldataload(add(paramData.offset, 0x20))
+                let u := add(paramData.offset, s)
+                callData.offset := add(u, 0x20)
+                callData.length := calldataload(u)
+            }
+            (bool success, bytes memory returnData) = contractAddr.staticcall(callData);
+            if (!success) {
+                revert ComposableExecutionFailed();
+            }
+            _validateConstraints(returnData, param.constraints);
+            return returnData;
+        } else if (param.fetcherType == InputParamFetcherType.BALANCE) {
+            address tokenAddr;
+            address account;
+            bytes calldata paramData = param.paramData;
+
+            // expect paramData to be abi.encodePacked(address token, address account)
+            // Validate exact length requirement
+            if (paramData.length != 40) {
+                revert InvalidParameterEncoding("Invalid paramData length");
+            }
+            assembly {
+                tokenAddr := shr(96, calldataload(paramData.offset))
+                account := shr(96, calldataload(add(paramData.offset, 0x14)))
+            }
+
+            uint256 balance;
+            if (tokenAddr == address(0)) {
+                balance = account.balance;
+            } else {
+                balance = IERC20(tokenAddr).balanceOf(account);
+            }
+            _validateConstraints(abi.encode(balance), param.constraints);
+            return abi.encode(balance);
+        } else {
+            revert InvalidParameterEncoding("Invalid param fetcher type");
+        }
+    }
+
+    // Process the output parameters
+    function processOutputs(OutputParam[] calldata outputParams, bytes memory returnData, address account) internal {
+        uint256 length = outputParams.length;
+        for (uint256 i; i < length; i++) {
+            processOutput(outputParams[i], returnData, account);
+        }
+    }
+
+    // Process a single output parameter and write to storage
+    function processOutput(OutputParam calldata param, bytes memory, address account) internal {
+        // only static types are supported for now as return values
+        // can also process all the static return values which are before the first dynamic return value in the
+        // returnData
+        if (param.fetcherType == OutputParamFetcherType.EXEC_RESULT) {
+            revert ExecResultNotSupported();
+        } else if (param.fetcherType == OutputParamFetcherType.STATIC_CALL) {
+            uint256 returnValues;
+            address sourceContract;
+            bytes calldata sourceCallData;
+            address targetStorageContract;
+            bytes32 targetStorageSlot;
+            bytes calldata paramData = param.paramData;
+            assembly {
+                returnValues := calldataload(paramData.offset)
+                sourceContract := calldataload(add(paramData.offset, 0x20))
+                let s := calldataload(add(paramData.offset, 0x40))
+                let u := add(paramData.offset, s)
+                sourceCallData.offset := add(u, 0x20)
+                sourceCallData.length := calldataload(u)
+                targetStorageContract := calldataload(add(paramData.offset, 0x60))
+                targetStorageSlot := calldataload(add(paramData.offset, 0x80))
+            }
+            (bool outputSuccess, bytes memory outputReturnData) = sourceContract.staticcall(sourceCallData);
+            if (!outputSuccess) {
+                revert Output_StaticCallFailed();
+            }
+            _parseReturnDataAndWriteToStorage(
+                returnValues, outputReturnData, targetStorageContract, targetStorageSlot, account
+            );
+        } else {
+            revert InvalidOutputParamFetcherType();
+        }
+    }
+
+    /// @dev Validate the constraints => compare the value with the reference data
+    function _validateConstraints(bytes memory rawValue, Constraint[] calldata constraints) private pure {
+        if (constraints.length > 0) {
+            for (uint256 i; i < constraints.length; i++) {
+                Constraint memory constraint = constraints[i];
+                bytes32 returnValue;
+                assembly {
+                    returnValue := mload(add(rawValue, add(0x20, mul(i, 0x20))))
+                }
+                if (constraint.constraintType == ConstraintType.EQ) {
+                    if (returnValue != bytes32(constraint.referenceData)) {
+                        revert ConstraintNotMet(ConstraintType.EQ);
+                    }
+                } else if (constraint.constraintType == ConstraintType.GTE) {
+                    if (returnValue < bytes32(constraint.referenceData)) {
+                        revert ConstraintNotMet(ConstraintType.GTE);
+                    }
+                } else if (constraint.constraintType == ConstraintType.LTE) {
+                    if (returnValue > bytes32(constraint.referenceData)) {
+                        revert ConstraintNotMet(ConstraintType.LTE);
+                    }
+                } else if (constraint.constraintType == ConstraintType.IN) {
+                    (bytes32 lowerBound, bytes32 upperBound) = abi.decode(constraint.referenceData, (bytes32, bytes32));
+                    if (returnValue < lowerBound || returnValue > upperBound) {
+                        revert ConstraintNotMet(ConstraintType.IN);
+                    }
+                } else {
+                    revert InvalidConstraintType();
+                }
+            }
+        }
+    }
+
+    /// @dev Parse the return data and write to the appropriate storage contract
+    function _parseReturnDataAndWriteToStorage(
+        uint256 returnValues,
+        bytes memory returnData,
+        address targetStorageContract,
+        bytes32 targetStorageSlot,
+        address account
+    )
+        internal
+    {
+        for (uint256 i; i < returnValues; i++) {
+            bytes32 value;
+            assembly {
+                value := mload(add(returnData, add(0x20, mul(i, 0x20))))
+            }
+            Storage(targetStorageContract)
+                .writeStorage({
+                slot: keccak256(abi.encodePacked(targetStorageSlot, i)), value: value, account: account
+            });
+        }
+    }
+}

--- a/packages/smart-vault-modules/src/vendor/composability/Storage.sol
+++ b/packages/smart-vault-modules/src/vendor/composability/Storage.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+// Vendored from bcnmy/composable-batch-erc (MIT) @ 71d43fead3b836ee9cb5cebeac4f96a68bf21dc3. No modifications.
+
+/**
+ * @title Storage
+ * @dev Contract to handle generic storage operations with cross-chain support
+ */
+contract Storage {
+    error SlotNotInitialized();
+
+    // Mapping to track initialized slots
+    mapping(bytes32 => bool) private initializedSlots;
+
+    // Mapping to track length of dynamic data
+    mapping(bytes32 => uint256) private dynamicDataLength;
+
+    /**
+     * @dev Internal function to write a value to a specific storage slot
+     */
+    function _writeStorage(bytes32 slot, bytes32 value, bytes32 namespace) private {
+        bytes32 namespacedSlot = getNamespacedSlot(namespace, slot);
+        initializedSlots[namespacedSlot] = true;
+        assembly {
+            sstore(namespacedSlot, value)
+        }
+    }
+
+    /**
+     * @dev Write a value to a specific storage slot
+     * @param slot The storage slot to write to
+     * @param value The value to write
+     */
+    function writeStorage(bytes32 slot, bytes32 value, address account) external {
+        bytes32 namespace = getNamespace(account, msg.sender);
+        _writeStorage(slot, value, namespace);
+    }
+
+    /**
+     * @dev Read a value from a specific namespace and slot
+     * @param namespace The namespace (typically a contract address)
+     * @param slot The storage slot to read from
+     * @return The value stored at the specified namespaced slot
+     */
+    function readStorage(bytes32 namespace, bytes32 slot) external view returns (bytes32) {
+        bytes32 namespacedSlot = getNamespacedSlot(namespace, slot);
+        if (!initializedSlots[namespacedSlot]) {
+            revert SlotNotInitialized();
+        }
+        bytes32 value;
+        assembly {
+            value := sload(namespacedSlot)
+        }
+        return value;
+    }
+
+    /**
+     * @dev Generates a namespaced slot
+     * @param namespace The namespace (typically a contract address)
+     * @param slot The storage slot to read from
+     * @return The namespaced slot
+     */
+    function getNamespacedSlot(bytes32 namespace, bytes32 slot) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(namespace, slot));
+    }
+
+    /**
+     * @dev Generates a namespace for a given account and caller
+     * @param account The account address
+     * @param caller The caller address
+     * @return The generated namespace
+     */
+    function getNamespace(address account, address caller) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(account, caller));
+    }
+
+    /**
+     * @dev Check if a slot has been initialized
+     */
+    function isSlotInitialized(bytes32 namespace, bytes32 slot) external view returns (bool) {
+        bytes32 namespacedSlot = getNamespacedSlot(namespace, slot);
+        return initializedSlots[namespacedSlot];
+    }
+}

--- a/packages/smart-vault-modules/test/ComposableExecutionModule.t.sol
+++ b/packages/smart-vault-modules/test/ComposableExecutionModule.t.sol
@@ -1,0 +1,613 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { Test } from "forge-std/Test.sol";
+
+import { ComposableExecutionModule } from "src/ComposableExecutionModule.sol";
+import { Call, ISmartVault } from "src/interfaces/ISmartVault.sol";
+import {
+    ComposableExecution,
+    Constraint,
+    ConstraintType,
+    InputParam,
+    InputParamFetcherType,
+    InputParamType,
+    OutputParam,
+    OutputParamFetcherType
+} from "src/vendor/composability/ComposabilityDataTypes.sol";
+import { ComposableExecutionLib } from "src/vendor/composability/ComposableExecutionLib.sol";
+import { Storage } from "src/vendor/composability/Storage.sol";
+import { ISmartVaultFactory, Signer } from "test/interfaces/ISmartVaultFactory.sol";
+
+contract ComposableExecutionModuleTest is Test {
+    /* -------------------------------------------------------------------------- */
+    /*                                  CONSTANTS                                 */
+    /* -------------------------------------------------------------------------- */
+
+    /// @dev Deployed SmartVaultFactory on Base.
+    ISmartVaultFactory constant FACTORY = ISmartVaultFactory(0x8E6Af8Ed94E87B4402D0272C5D6b0D47F0483e7C);
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   ERRORS                                   */
+    /* -------------------------------------------------------------------------- */
+
+    error OnlyModule();
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   EVENTS                                   */
+    /* -------------------------------------------------------------------------- */
+
+    event ExecutedComposable(address indexed account, uint256 executions);
+
+    /* -------------------------------------------------------------------------- */
+    /*                                    STATE                                   */
+    /* -------------------------------------------------------------------------- */
+
+    ISmartVault vault;
+    ComposableExecutionModule module;
+    Storage store;
+
+    TestToken tokenIn;
+    TestToken tokenOut;
+    MockSwap swapPool;
+
+    address owner;
+    uint256 ownerKey;
+    address recipient;
+
+    /* -------------------------------------------------------------------------- */
+    /*                                    SETUP                                   */
+    /* -------------------------------------------------------------------------- */
+
+    function setUp() public {
+        vm.createSelectFork("base");
+
+        (owner, ownerKey) = makeAddrAndKey("OWNER");
+        recipient = makeAddr("RECIPIENT");
+
+        module = new ComposableExecutionModule();
+        store = new Storage();
+
+        tokenIn = new TestToken();
+        tokenOut = new TestToken();
+        swapPool = new MockSwap(tokenIn, tokenOut);
+
+        vault = _createVaultWithModule(0);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   HELPERS                                  */
+    /* -------------------------------------------------------------------------- */
+
+    function _createVaultWithModule(uint256 salt_) internal returns (ISmartVault) {
+        Signer[] memory signers = new Signer[](1);
+        signers[0] = Signer({ slot1: bytes32(uint256(uint160(owner))), slot2: bytes32(0) });
+        ISmartVault v = ISmartVault(FACTORY.createAccount(owner, signers, 1, salt_));
+        vm.prank(address(v));
+        v.enableModule(address(module));
+        return v;
+    }
+
+    function _createVaultWithoutModule(uint256 salt_) internal returns (ISmartVault) {
+        Signer[] memory signers = new Signer[](1);
+        signers[0] = Signer({ slot1: bytes32(uint256(uint160(owner))), slot2: bytes32(0) });
+        return ISmartVault(FACTORY.createAccount(owner, signers, 1, salt_));
+    }
+
+    function _noConstraints() internal pure returns (Constraint[] memory) {
+        return new Constraint[](0);
+    }
+
+    function _constraint(ConstraintType type_, bytes memory referenceData_)
+        internal
+        pure
+        returns (Constraint[] memory)
+    {
+        Constraint[] memory constraints = new Constraint[](1);
+        constraints[0] = Constraint({ constraintType: type_, referenceData: referenceData_ });
+        return constraints;
+    }
+
+    function _targetInput(address target_) internal pure returns (InputParam memory) {
+        return InputParam({
+            paramType: InputParamType.TARGET,
+            fetcherType: InputParamFetcherType.RAW_BYTES,
+            paramData: abi.encode(target_),
+            constraints: _noConstraints()
+        });
+    }
+
+    function _rawCalldataInput(bytes memory data_) internal pure returns (InputParam memory) {
+        return InputParam({
+            paramType: InputParamType.CALL_DATA,
+            fetcherType: InputParamFetcherType.RAW_BYTES,
+            paramData: data_,
+            constraints: _noConstraints()
+        });
+    }
+
+    function _balanceCalldataInput(
+        address token_,
+        address account_,
+        Constraint[] memory constraints_
+    )
+        internal
+        pure
+        returns (InputParam memory)
+    {
+        return InputParam({
+            paramType: InputParamType.CALL_DATA,
+            fetcherType: InputParamFetcherType.BALANCE,
+            paramData: abi.encodePacked(token_, account_),
+            constraints: constraints_
+        });
+    }
+
+    function _noOutputs() internal pure returns (OutputParam[] memory) {
+        return new OutputParam[](0);
+    }
+
+    /// @dev A raw call as a single composable entry: selector as functionSig, target raw, args raw.
+    function _rawEntry(address target_, bytes memory callData_) internal pure returns (ComposableExecution memory) {
+        bytes4 sig;
+        assembly {
+            sig := mload(add(callData_, 0x20))
+        }
+        bytes memory args = new bytes(callData_.length - 4);
+        for (uint256 i; i < args.length; i++) {
+            args[i] = callData_[i + 4];
+        }
+        InputParam[] memory inputs = new InputParam[](2);
+        inputs[0] = _targetInput(target_);
+        inputs[1] = _rawCalldataInput(args);
+        return ComposableExecution({ functionSig: sig, inputParams: inputs, outputParams: _noOutputs() });
+    }
+
+    /// @dev transfer(recipient, <runtime balance of token_ held by account_>) with optional constraints.
+    function _transferAllEntry(
+        address token_,
+        address account_,
+        address recipient_,
+        Constraint[] memory constraints_
+    )
+        internal
+        pure
+        returns (ComposableExecution memory)
+    {
+        InputParam[] memory inputs = new InputParam[](3);
+        inputs[0] = _targetInput(token_);
+        inputs[1] = _rawCalldataInput(abi.encode(recipient_));
+        inputs[2] = _balanceCalldataInput(token_, account_, constraints_);
+        return ComposableExecution({
+            functionSig: TestToken.transfer.selector, inputParams: inputs, outputParams: _noOutputs()
+        });
+    }
+
+    /// @dev Approve + swap entries shared by the swap-shaped tests.
+    function _swapEntries(uint256 amountIn_) internal view returns (ComposableExecution[] memory) {
+        ComposableExecution[] memory entries = new ComposableExecution[](3);
+        entries[0] = _rawEntry(address(tokenIn), abi.encodeCall(TestToken.approve, (address(swapPool), amountIn_)));
+        entries[1] = _rawEntry(address(swapPool), abi.encodeCall(MockSwap.swap, (amountIn_)));
+        return entries;
+    }
+
+    function _execute(ISmartVault vault_, ComposableExecution[] memory entries_) internal {
+        vm.prank(address(vault_));
+        module.executeComposable(entries_);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                              LITERAL BATCHES                               */
+    /* -------------------------------------------------------------------------- */
+
+    function test_literalBatch_matchesExecuteFromModule() public {
+        uint256 amount = 1000e18;
+        ISmartVault plainVault = _createVaultWithModule(1);
+        tokenIn.mint(address(vault), amount);
+        tokenIn.mint(address(plainVault), amount);
+
+        // Composable path with raw-bytes-only entries.
+        ComposableExecution[] memory entries = new ComposableExecution[](2);
+        entries[0] = _rawEntry(address(tokenIn), abi.encodeCall(TestToken.approve, (address(swapPool), amount)));
+        entries[1] = _rawEntry(address(tokenIn), abi.encodeCall(TestToken.transfer, (recipient, amount)));
+
+        vm.expectEmit(true, false, false, true, address(module));
+        emit ExecutedComposable(address(vault), 2);
+        _execute(vault, entries);
+
+        // Same calls through the plain executeFromModule path.
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({
+            target: address(tokenIn), value: 0, data: abi.encodeCall(TestToken.approve, (address(swapPool), amount))
+        });
+        calls[1] =
+            Call({ target: address(tokenIn), value: 0, data: abi.encodeCall(TestToken.transfer, (recipient, amount)) });
+        vm.prank(address(module));
+        plainVault.executeFromModule(calls);
+
+        // Both paths end in identical state.
+        assertEq(tokenIn.balanceOf(address(vault)), 0);
+        assertEq(tokenIn.balanceOf(address(plainVault)), 0);
+        assertEq(tokenIn.balanceOf(recipient), 2 * amount);
+        assertEq(tokenIn.allowance(address(vault), address(swapPool)), amount);
+        assertEq(tokenIn.allowance(address(plainVault), address(swapPool)), amount);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                               BALANCE FETCHER                              */
+    /* -------------------------------------------------------------------------- */
+
+    function test_balanceFetcher_swapThenTransferAll() public {
+        uint256 amountIn = 1000e18;
+        uint256 actualOut = 987e18;
+        tokenIn.mint(address(vault), amountIn);
+        swapPool.setNextOutput(actualOut);
+
+        ComposableExecution[] memory entries = _swapEntries(amountIn);
+        entries[2] = _transferAllEntry(address(tokenOut), address(vault), recipient, _noConstraints());
+
+        _execute(vault, entries);
+
+        // The full variable swap output reaches the recipient; nothing strands in the vault.
+        assertEq(tokenOut.balanceOf(recipient), actualOut);
+        assertEq(tokenOut.balanceOf(address(vault)), 0);
+        assertEq(tokenIn.balanceOf(address(vault)), 0);
+    }
+
+    function testFuzz_balanceFetcher_swapThenTransferAll(uint256 actualOut_) public {
+        actualOut_ = bound(actualOut_, 1, type(uint128).max);
+        uint256 amountIn = 1000e18;
+        tokenIn.mint(address(vault), amountIn);
+        swapPool.setNextOutput(actualOut_);
+
+        ComposableExecution[] memory entries = _swapEntries(amountIn);
+        entries[2] = _transferAllEntry(address(tokenOut), address(vault), recipient, _noConstraints());
+
+        _execute(vault, entries);
+
+        assertEq(tokenOut.balanceOf(recipient), actualOut_);
+        assertEq(tokenOut.balanceOf(address(vault)), 0);
+    }
+
+    function test_balanceFetcher_nativeEth() public {
+        vm.deal(address(vault), 5 ether);
+
+        // Send the vault's entire native balance: VALUE is fetched at execution time via the BALANCE fetcher.
+        InputParam[] memory inputs = new InputParam[](2);
+        inputs[0] = _targetInput(recipient);
+        inputs[1] = InputParam({
+            paramType: InputParamType.VALUE,
+            fetcherType: InputParamFetcherType.BALANCE,
+            paramData: abi.encodePacked(address(0), address(vault)),
+            constraints: _noConstraints()
+        });
+        ComposableExecution[] memory entries = new ComposableExecution[](1);
+        entries[0] = ComposableExecution({ functionSig: bytes4(0), inputParams: inputs, outputParams: _noOutputs() });
+
+        _execute(vault, entries);
+
+        assertEq(address(vault).balance, 0);
+        assertEq(recipient.balance, 5 ether);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                             STATIC_CALL FETCHER                            */
+    /* -------------------------------------------------------------------------- */
+
+    function test_staticCallFetcher() public {
+        uint256 quoted = 777e18;
+        tokenOut.mint(address(vault), 1000e18);
+        swapPool.setNextOutput(quoted);
+
+        // transfer(recipient, <MockSwap.nextOutput() read at execution time>)
+        InputParam[] memory inputs = new InputParam[](3);
+        inputs[0] = _targetInput(address(tokenOut));
+        inputs[1] = _rawCalldataInput(abi.encode(recipient));
+        inputs[2] = InputParam({
+            paramType: InputParamType.CALL_DATA,
+            fetcherType: InputParamFetcherType.STATIC_CALL,
+            paramData: abi.encode(address(swapPool), abi.encodeCall(swapPool.nextOutput, ())),
+            constraints: _noConstraints()
+        });
+        ComposableExecution[] memory entries = new ComposableExecution[](1);
+        entries[0] = ComposableExecution({
+            functionSig: TestToken.transfer.selector, inputParams: inputs, outputParams: _noOutputs()
+        });
+
+        _execute(vault, entries);
+
+        assertEq(tokenOut.balanceOf(recipient), quoted);
+        assertEq(tokenOut.balanceOf(address(vault)), 1000e18 - quoted);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                 CONSTRAINTS                                */
+    /* -------------------------------------------------------------------------- */
+
+    function test_constraintGTE_revertsAtomically() public {
+        uint256 amountIn = 1000e18;
+        uint256 minOut = 990e18;
+        tokenIn.mint(address(vault), amountIn);
+        swapPool.setNextOutput(minOut - 1);
+
+        ComposableExecution[] memory entries = _swapEntries(amountIn);
+        entries[2] = _transferAllEntry(
+            address(tokenOut), address(vault), recipient, _constraint(ConstraintType.GTE, abi.encode(minOut))
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(ComposableExecutionLib.ConstraintNotMet.selector, ConstraintType.GTE));
+        _execute(vault, entries);
+
+        // The whole batch reverted: the swap in entry 1 was rolled back too.
+        assertEq(tokenIn.balanceOf(address(vault)), amountIn);
+        assertEq(tokenOut.balanceOf(address(vault)), 0);
+        assertEq(tokenOut.balanceOf(recipient), 0);
+    }
+
+    function test_constraintGTE_passes() public {
+        uint256 amountIn = 1000e18;
+        uint256 minOut = 990e18;
+        tokenIn.mint(address(vault), amountIn);
+        swapPool.setNextOutput(minOut);
+
+        ComposableExecution[] memory entries = _swapEntries(amountIn);
+        entries[2] = _transferAllEntry(
+            address(tokenOut), address(vault), recipient, _constraint(ConstraintType.GTE, abi.encode(minOut))
+        );
+
+        _execute(vault, entries);
+
+        assertEq(tokenOut.balanceOf(recipient), minOut);
+    }
+
+    function test_constraintEQ() public {
+        tokenOut.mint(address(vault), 100e18);
+
+        ComposableExecution[] memory pass = new ComposableExecution[](1);
+        pass[0] = _transferAllEntry(
+            address(tokenOut), address(vault), recipient, _constraint(ConstraintType.EQ, abi.encode(100e18))
+        );
+        _execute(vault, pass);
+        assertEq(tokenOut.balanceOf(recipient), 100e18);
+
+        tokenOut.mint(address(vault), 99e18);
+        ComposableExecution[] memory fail = new ComposableExecution[](1);
+        fail[0] = _transferAllEntry(
+            address(tokenOut), address(vault), recipient, _constraint(ConstraintType.EQ, abi.encode(100e18))
+        );
+        vm.expectRevert(abi.encodeWithSelector(ComposableExecutionLib.ConstraintNotMet.selector, ConstraintType.EQ));
+        _execute(vault, fail);
+    }
+
+    function test_constraintLTE() public {
+        tokenOut.mint(address(vault), 100e18);
+
+        ComposableExecution[] memory pass = new ComposableExecution[](1);
+        pass[0] = _transferAllEntry(
+            address(tokenOut), address(vault), recipient, _constraint(ConstraintType.LTE, abi.encode(100e18))
+        );
+        _execute(vault, pass);
+        assertEq(tokenOut.balanceOf(recipient), 100e18);
+
+        tokenOut.mint(address(vault), 101e18);
+        ComposableExecution[] memory fail = new ComposableExecution[](1);
+        fail[0] = _transferAllEntry(
+            address(tokenOut), address(vault), recipient, _constraint(ConstraintType.LTE, abi.encode(100e18))
+        );
+        vm.expectRevert(abi.encodeWithSelector(ComposableExecutionLib.ConstraintNotMet.selector, ConstraintType.LTE));
+        _execute(vault, fail);
+    }
+
+    function test_constraintIN() public {
+        tokenOut.mint(address(vault), 100e18);
+
+        ComposableExecution[] memory pass = new ComposableExecution[](1);
+        pass[0] = _transferAllEntry(
+            address(tokenOut),
+            address(vault),
+            recipient,
+            _constraint(ConstraintType.IN, abi.encode(bytes32(uint256(50e18)), bytes32(uint256(150e18))))
+        );
+        _execute(vault, pass);
+        assertEq(tokenOut.balanceOf(recipient), 100e18);
+
+        tokenOut.mint(address(vault), 200e18);
+        ComposableExecution[] memory fail = new ComposableExecution[](1);
+        fail[0] = _transferAllEntry(
+            address(tokenOut),
+            address(vault),
+            recipient,
+            _constraint(ConstraintType.IN, abi.encode(bytes32(uint256(50e18)), bytes32(uint256(150e18))))
+        );
+        vm.expectRevert(abi.encodeWithSelector(ComposableExecutionLib.ConstraintNotMet.selector, ConstraintType.IN));
+        _execute(vault, fail);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                               OUTPUT CAPTURE                               */
+    /* -------------------------------------------------------------------------- */
+
+    function test_outputCapture_staticCall() public {
+        uint256 amountIn = 1000e18;
+        uint256 actualOut = 987e18;
+        tokenIn.mint(address(vault), amountIn);
+        swapPool.setNextOutput(actualOut);
+
+        bytes32 slot = keccak256("test.swapOutput");
+
+        // Swap, then capture the vault's post-swap tokenOut balance to Storage.
+        OutputParam[] memory outputs = new OutputParam[](1);
+        outputs[0] = OutputParam({
+            fetcherType: OutputParamFetcherType.STATIC_CALL,
+            paramData: abi.encode(
+                uint256(1),
+                address(tokenOut),
+                abi.encodeCall(tokenOut.balanceOf, (address(vault))),
+                address(store),
+                slot
+            )
+        });
+
+        ComposableExecution[] memory entries = _swapEntries(amountIn);
+        entries[2] = ComposableExecution({
+            functionSig: MockSwap.swap.selector, inputParams: new InputParam[](0), outputParams: outputs
+        });
+        // Entry 2 has no TARGET so it resolves to address(0): predicate/capture-only, no execution.
+
+        _execute(vault, entries);
+
+        bytes32 namespace = store.getNamespace(address(vault), address(module));
+        bytes32 captured = store.readStorage(namespace, keccak256(abi.encodePacked(slot, uint256(0))));
+        assertEq(uint256(captured), actualOut);
+
+        // A second vault capturing under the same slot lands in its own namespace.
+        ISmartVault vault2 = _createVaultWithModule(2);
+        uint256 actualOut2 = 123e18;
+        tokenIn.mint(address(vault2), amountIn);
+        swapPool.setNextOutput(actualOut2);
+
+        OutputParam[] memory outputs2 = new OutputParam[](1);
+        outputs2[0] = OutputParam({
+            fetcherType: OutputParamFetcherType.STATIC_CALL,
+            paramData: abi.encode(
+                uint256(1),
+                address(tokenOut),
+                abi.encodeCall(tokenOut.balanceOf, (address(vault2))),
+                address(store),
+                slot
+            )
+        });
+        ComposableExecution[] memory entries2 = _swapEntries(amountIn);
+        entries2[2] = ComposableExecution({
+            functionSig: MockSwap.swap.selector, inputParams: new InputParam[](0), outputParams: outputs2
+        });
+        _execute(vault2, entries2);
+
+        bytes32 namespace2 = store.getNamespace(address(vault2), address(module));
+        assertEq(uint256(store.readStorage(namespace2, keccak256(abi.encodePacked(slot, uint256(0))))), actualOut2);
+        // First vault's captured value is untouched.
+        assertEq(uint256(store.readStorage(namespace, keccak256(abi.encodePacked(slot, uint256(0))))), actualOut);
+    }
+
+    function test_outputCapture_execResult_reverts() public {
+        OutputParam[] memory outputs = new OutputParam[](1);
+        outputs[0] = OutputParam({
+            fetcherType: OutputParamFetcherType.EXEC_RESULT,
+            paramData: abi.encode(uint256(1), address(store), bytes32(0))
+        });
+
+        ComposableExecution[] memory entries = new ComposableExecution[](1);
+        entries[0] = ComposableExecution({
+            functionSig: TestToken.transfer.selector, inputParams: new InputParam[](0), outputParams: outputs
+        });
+
+        vm.expectRevert(ComposableExecutionLib.ExecResultNotSupported.selector);
+        _execute(vault, entries);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                ACCESS CONTROL                              */
+    /* -------------------------------------------------------------------------- */
+
+    function test_revertsWhen_moduleNotEnabled() public {
+        ISmartVault bareVault = _createVaultWithoutModule(3);
+        tokenOut.mint(address(bareVault), 100e18);
+
+        ComposableExecution[] memory entries = new ComposableExecution[](1);
+        entries[0] = _transferAllEntry(address(tokenOut), address(bareVault), recipient, _noConstraints());
+
+        vm.expectRevert(OnlyModule.selector);
+        _execute(bareVault, entries);
+
+        assertEq(tokenOut.balanceOf(address(bareVault)), 100e18);
+    }
+
+    function test_attackerCannotExecuteForOtherVault() public {
+        tokenOut.mint(address(vault), 100e18);
+        address attacker = makeAddr("ATTACKER");
+
+        // Entries shaped to drain the vault's tokenOut. The module executes for msg.sender only, so the
+        // loop-back targets the attacker address, which has no executeFromModule.
+        ComposableExecution[] memory entries = new ComposableExecution[](1);
+        entries[0] = _transferAllEntry(address(tokenOut), address(vault), attacker, _noConstraints());
+
+        vm.prank(attacker);
+        vm.expectRevert();
+        module.executeComposable(entries);
+
+        assertEq(tokenOut.balanceOf(address(vault)), 100e18);
+        assertEq(tokenOut.balanceOf(attacker), 0);
+    }
+
+    function test_revertsWhen_moduleDisabled() public {
+        ISmartVault v = _createVaultWithModule(4);
+        tokenOut.mint(address(v), 100e18);
+
+        ComposableExecution[] memory entries = new ComposableExecution[](1);
+        entries[0] = _transferAllEntry(address(tokenOut), address(v), recipient, _noConstraints());
+        _execute(v, entries);
+        assertEq(tokenOut.balanceOf(recipient), 100e18);
+
+        vm.prank(address(v));
+        v.disableModule(address(module));
+
+        tokenOut.mint(address(v), 50e18);
+        ComposableExecution[] memory entries2 = new ComposableExecution[](1);
+        entries2[0] = _transferAllEntry(address(tokenOut), address(v), recipient, _noConstraints());
+
+        vm.expectRevert(OnlyModule.selector);
+        _execute(v, entries2);
+
+        assertEq(tokenOut.balanceOf(address(v)), 50e18);
+    }
+}
+
+/// @dev Minimal mintable ERC-20 for exercising the module.
+contract TestToken {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to_, uint256 amount_) external {
+        balanceOf[to_] += amount_;
+    }
+
+    function transfer(address to_, uint256 amount_) external returns (bool) {
+        balanceOf[msg.sender] -= amount_;
+        balanceOf[to_] += amount_;
+        return true;
+    }
+
+    function transferFrom(address from_, address to_, uint256 amount_) external returns (bool) {
+        allowance[from_][msg.sender] -= amount_;
+        balanceOf[from_] -= amount_;
+        balanceOf[to_] += amount_;
+        return true;
+    }
+
+    function approve(address spender_, uint256 amount_) external returns (bool) {
+        allowance[msg.sender][spender_] = amount_;
+        return true;
+    }
+}
+
+/// @dev Swap stub whose output is configured per test, modelling quote-time vs execution-time drift.
+contract MockSwap {
+    TestToken public immutable TOKEN_IN;
+    TestToken public immutable TOKEN_OUT;
+
+    uint256 public nextOutput;
+
+    constructor(TestToken tokenIn_, TestToken tokenOut_) {
+        TOKEN_IN = tokenIn_;
+        TOKEN_OUT = tokenOut_;
+    }
+
+    function setNextOutput(uint256 nextOutput_) external {
+        nextOutput = nextOutput_;
+    }
+
+    function swap(uint256 amountIn_) external {
+        TOKEN_IN.transferFrom(msg.sender, address(this), amountIn_);
+        TOKEN_OUT.mint(msg.sender, nextOutput);
+    }
+}


### PR DESCRIPTION
## Description

Adds a ComposableExecutionModule (ERC-8211 smart batching executor) so SmartVault batches can resolve parameters at execution time (live balances, static reads) and validate them against inline constraints, instead of freezing every amount at signing time.

## Changes made

- `src/vendor/composability/`: Biconomy's MIT reference implementation (`bcnmy/composable-batch-erc` @ `71d43fe`), vendored with three documented modifications: local `Execution` struct (no erc7579 dependency), `require(cond, CustomError())` rewritten to `if/revert` for solc 0.8.23, and `EXEC_RESULT` output capture reverting with `ExecResultNotSupported` (the vault's `executeFromModule` discards return data; the upstream branch would read out-of-bounds memory). `STATIC_CALL` output capture covers the same use cases.
- `src/ComposableExecutionModule.sol`: stateless adapter. The account is always `msg.sender` (no account parameter), so authorization inherits the userop signature scheme via the loop-back flow: `vault.execute(module, executeComposable(...))` then per-entry `vault.executeFromModule(Call)`, gated by `onlyModule`. Per-entry execution is required so later entries' fetchers observe earlier entries' effects.
- `src/interfaces/ISmartVault.sol`: adds the single-call `executeFromModule(Call)` overload (present on `ModuleManager`).
- `script/ComposableExecutionModule.s.sol`: CREATE2 deploy of the Storage singleton + module (same address on every chain; salts `splits.composabilityStorage.v1` / `splits.composableExecutionModule.v1`).

## How has this been tested?

`BASE_RPC_URL=... pnpm test`: 15 new fork tests against the real SmartVaultFactory on Base, covering literal-batch parity with `executeFromModule`, runtime BALANCE injection (ERC-20 and native, fuzzed variable swap output), STATIC_CALL fetcher, all four constraint types with atomic batch revert on failure, Storage output capture with per-vault namespace isolation, `ExecResultNotSupported`, `OnlyModule` (not enabled / disabled), and an attacker attempting to execute against another vault (harmless no-op against themselves).

Note: the pre-existing `AutoEarnModule.testFuzz_deposit` fails at fork head due to Aave's Base USDC supply cap; it fails identically without this branch.

## Other notes

- Security model summary: an enabled module has unrestricted `executeFromModule` power, so the module must never accept an account parameter. A direct EOA caller reverts (call to a codeless `executeFromModule`); a contract caller hits `OnlyModule` unless it enabled the module on itself. The module is stateless and holds no assets; reentrancy only lets a target execute for itself.
- Runtime-resolved entry `value` works (verified by the native ETH test), which unlocks native swap-and-send later on the server side.
- Server counterpart: splits#feature/composable-executions (encoder, JIT enableModule, swap provider integration behind an Amplitude flag).
- Needs an audit before deployment; enabling is per-account via an idempotent `enableModule` self-call that the server bundles just-in-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
