### PR TITLE
spike: chainless state updates for SmartVault v1.1

### DIFF
--- a/packages/smart-vaults/src/signers/MultiSigner.sol
+++ b/packages/smart-vaults/src/signers/MultiSigner.sol
@@ -195,23 +195,6 @@ library MultiSignerLib {
     }
 
     /**
-     * @notice Replaces the entire signer set with `signers_` and `threshold_`.
-     *
-     * @dev Deliberately independent of current state so the same call replays correctly on chains
-     *      whose signer sets have drifted (the recovery scenario).
-     */
-    function resetSigners(MultiSigner storage $_, Signer[] calldata signers_, uint8 threshold_) internal {
-        // ponytail: full 256-slot scan (~256 cold SLOADs); occupancy bitmap if the gas matters.
-        for (uint256 i; i < 256; i++) {
-            if (!$_.signers[i].isEmptyMem()) delete $_.signers[i];
-        }
-
-        $_.signerCount = 0;
-
-        initializeSigners($_, signers_, threshold_);
-    }
-
-    /**
      * @notice Initialize the signers.
      *
      * @dev Intended to be called when initializing the signer set.

--- a/packages/smart-vaults/src/signers/MultiSigner.sol
+++ b/packages/smart-vaults/src/signers/MultiSigner.sol
@@ -39,6 +39,17 @@ library MultiSignerLib {
         bytes signatureData;
     }
 
+    /**
+     * @notice A single mutation in an atomic signer-set update.
+     * @dev Empty `signer` removes the signer at `index`; non-empty adds it at `index`. Applied
+     *      sequentially with set invariants (threshold vs count) validated once after the batch,
+     *      so remove-then-add at the same index (a signer swap) needs no intermediate juggling.
+     */
+    struct SignerSetOp {
+        uint8 index;
+        Signer signer;
+    }
+
     /* -------------------------------------------------------------------------- */
     /*                                   ERRORS                                   */
     /* -------------------------------------------------------------------------- */
@@ -145,6 +156,59 @@ library MultiSignerLib {
         if ($_.signerCount < threshold_) revert InvalidThreshold();
 
         $_.threshold = threshold_;
+    }
+
+    /**
+     * @notice Applies a batch of signer set mutations, validating invariants once at the end.
+     *
+     * @dev Reverts if an add targets an occupied index or a remove targets an empty one.
+     * @dev Reverts if the resulting set violates `1 <= threshold <= signerCount <= 255`.
+     *
+     * @param $_ Multi signer storage reference.
+     * @param ops_ Sequential mutations (see `SignerSetOp`).
+     * @param threshold_ New threshold; 0 keeps the current threshold.
+     */
+    function updateSignerSet(MultiSigner storage $_, SignerSetOp[] calldata ops_, uint8 threshold_) internal {
+        uint256 count = $_.signerCount;
+
+        for (uint256 i; i < ops_.length; i++) {
+            uint8 index = ops_[i].index;
+
+            if (ops_[i].signer.isEmpty()) {
+                if ($_.signers[index].isEmptyMem()) revert SignerNotPresent(index);
+                delete $_.signers[index];
+                count--;
+            } else {
+                if (!$_.signers[index].isEmptyMem()) revert SignerAlreadyPresent(index);
+                _addSigner($_, ops_[i].signer, index);
+                count++;
+            }
+        }
+
+        if (count > type(uint8).max) revert InvalidNumberOfSigners();
+
+        uint8 threshold = threshold_ == 0 ? $_.threshold : threshold_;
+        if (threshold == 0 || count < threshold) revert InvalidThreshold();
+
+        $_.signerCount = uint8(count);
+        $_.threshold = threshold;
+    }
+
+    /**
+     * @notice Replaces the entire signer set with `signers_` and `threshold_`.
+     *
+     * @dev Deliberately independent of current state so the same call replays correctly on chains
+     *      whose signer sets have drifted (the recovery scenario).
+     */
+    function resetSigners(MultiSigner storage $_, Signer[] calldata signers_, uint8 threshold_) internal {
+        // ponytail: full 256-slot scan (~256 cold SLOADs); occupancy bitmap if the gas matters.
+        for (uint256 i; i < 256; i++) {
+            if (!$_.signers[i].isEmptyMem()) delete $_.signers[i];
+        }
+
+        $_.signerCount = 0;
+
+        initializeSigners($_, signers_, threshold_);
     }
 
     /**

--- a/packages/smart-vaults/src/signers/Signer.sol
+++ b/packages/smart-vaults/src/signers/Signer.sol
@@ -76,6 +76,11 @@ library SignerLib {
     }
 
     /// @notice Returns true if both slot1 and slot2 are zero.
+    function isEmpty(Signer calldata signer_) internal pure returns (bool) {
+        return signer_.slot1 == ZERO && signer_.slot2 == ZERO;
+    }
+
+    /// @notice Returns true if both slot1 and slot2 are zero.
     function isEmptyMem(Signer memory signer_) internal pure returns (bool) {
         return signer_.slot1 == ZERO && signer_.slot2 == ZERO;
     }

--- a/packages/smart-vaults/src/utils/ERC1271.sol
+++ b/packages/smart-vaults/src/utils/ERC1271.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.23;
 
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 /**
  * @title ERC-1271
@@ -32,6 +33,16 @@ abstract contract ERC1271 is EIP712 {
      */
     bytes32 private constant _MESSAGE_TYPEHASH = keccak256("SplitMessage(bytes32 hash)");
 
+    /// @dev EIP-712 domain typehash without chainId. Signatures over this domain are valid on every
+    ///      chain where this account exists at the same address (guaranteed by CREATE2 deployment).
+    bytes32 private constant _CHAINLESS_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,address verifyingContract)");
+
+    /// @dev Discriminator prefix for ERC-1271 signature blobs. SPIKE NOTE: breaking change — v1.0
+    ///      blobs carry no prefix byte.
+    bytes1 private constant _SIG_DOMAIN_CHAIN_BOUND = 0x00;
+    bytes1 private constant _SIG_DOMAIN_CHAINLESS = 0x01;
+
     /* -------------------------------------------------------------------------- */
     /*                                 CONSTRUCTOR                                */
     /* -------------------------------------------------------------------------- */
@@ -58,7 +69,9 @@ abstract contract ERC1271 is EIP712 {
      * @return result `0x1626ba7e` if validation succeeded, else `0xffffffff`.
      */
     function isValidSignature(bytes32 hash_, bytes calldata signature_) public view virtual returns (bytes4) {
-        if (_isValidSignature(replaySafeHash(hash_), signature_)) {
+        bytes32 digest = signature_[0] == _SIG_DOMAIN_CHAINLESS ? chainlessReplaySafeHash(hash_) : replaySafeHash(hash_);
+
+        if (_isValidSignature(digest, signature_[1:])) {
             // bytes4(keccak256("isValidSignature(bytes32,bytes)"))
             return 0x1626ba7e;
         }
@@ -83,6 +96,18 @@ abstract contract ERC1271 is EIP712 {
         return _hashTypedDataV4(keccak256(abi.encode(_MESSAGE_TYPEHASH, hash_)));
     }
 
+    /**
+     * @dev Chain-agnostic sibling of `replaySafeHash`: same SplitMessage struct, but the domain
+     *      omits chainId so one signature verifies on every chain. Cross-account replay protection
+     *      is preserved via `verifyingContract`. Shared by the ChainlessUserOp validation path and
+     *      the chainless ERC-1271 flow.
+     *
+     * @param hash_ The original hash.
+     */
+    function chainlessReplaySafeHash(bytes32 hash_) public view virtual returns (bytes32) {
+        return _hashChainlessTypedData(keccak256(abi.encode(_MESSAGE_TYPEHASH, hash_)));
+    }
+
     /* -------------------------------------------------------------------------- */
     /*                             INTERNAL FUNCTIONS                             */
     /* -------------------------------------------------------------------------- */
@@ -97,4 +122,19 @@ abstract contract ERC1271 is EIP712 {
      * @return `true` is the signature is valid, else `false`.
      */
     function _isValidSignature(bytes32 hash_, bytes calldata signature_) internal view virtual returns (bool);
+
+    /// @dev Hashes `structHash` into the chainless (no chainId) EIP-712 domain.
+    function _hashChainlessTypedData(bytes32 structHash_) internal view returns (bytes32) {
+        return MessageHashUtils.toTypedDataHash(
+            keccak256(
+                abi.encode(
+                    _CHAINLESS_DOMAIN_TYPEHASH,
+                    keccak256(bytes(_EIP712Name())),
+                    keccak256(bytes(_EIP712Version())),
+                    address(this)
+                )
+            ),
+            structHash_
+        );
+    }
 }

--- a/packages/smart-vaults/src/utils/MultiSignerAuth.sol
+++ b/packages/smart-vaults/src/utils/MultiSignerAuth.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.23;
 
-import { MultiSigner } from "../signers/MultiSigner.sol";
+import { MultiSigner, MultiSignerLib } from "../signers/MultiSigner.sol";
 import { Signer } from "../signers/Signer.sol";
 
 /**
@@ -24,6 +24,15 @@ abstract contract MultiSignerAuth {
      */
     bytes32 private constant _MUTLI_SIGNER_AUTH_STORAGE_SLOT =
         0x3e5431599761dc1a6f375d94085bdcd73bc8fa7c6b3d455d31679f3080214700;
+
+    /**
+     * @dev Signer-state roles, granted per chainless userOp by signature verification (see
+     *      SmartVault). Threshold signers mutate the signer set; only the owner may wholesale
+     *      reset it. All signer-state mutations require a chainless context so state stays in
+     *      lockstep across chains.
+     */
+    uint8 internal constant ROLE_THRESHOLD = 1;
+    uint8 internal constant ROLE_OWNER = 2;
 
     /* -------------------------------------------------------------------------- */
     /*                                   STRUCT                                   */
@@ -64,6 +73,20 @@ abstract contract MultiSignerAuth {
      * @param threshold The new threshold for the signer set.
      */
     event UpdateThreshold(uint8 threshold);
+
+    /**
+     * @notice Emitted when a batch signer set update is applied.
+     * @param ops The applied mutations.
+     * @param threshold The effective threshold after the batch.
+     */
+    event UpdateSignerSet(MultiSignerLib.SignerSetOp[] ops, uint8 threshold);
+
+    /**
+     * @notice Emitted when the signer set is wholesale replaced.
+     * @param signers The new signer set.
+     * @param threshold The new threshold.
+     */
+    event ResetSigners(Signer[] signers, uint8 threshold);
 
     /* -------------------------------------------------------------------------- */
     /*                                  MODIFIERS                                 */
@@ -107,6 +130,8 @@ abstract contract MultiSignerAuth {
      * @param index_ The index to register the signer.
      */
     function addSigner(Signer calldata signer_, uint8 index_) external onlyAuthorized {
+        _checkChainlessRole(ROLE_THRESHOLD);
+
         _getMultiSignerStorage().addSigner(signer_, index_);
 
         emit AddSigner(index_, signer_);
@@ -121,6 +146,8 @@ abstract contract MultiSignerAuth {
      * @param index_ The index of the signer to be removed.
      */
     function removeSigner(uint8 index_) external onlyAuthorized {
+        _checkChainlessRole(ROLE_THRESHOLD);
+
         Signer memory signer = _getMultiSignerStorage().removeSigner(index_);
 
         emit RemoveSigner(index_, signer);
@@ -135,9 +162,46 @@ abstract contract MultiSignerAuth {
      * @param threshold_ The new signer set threshold.
      */
     function updateThreshold(uint8 threshold_) external onlyAuthorized {
+        _checkChainlessRole(ROLE_THRESHOLD);
+
         _getMultiSignerStorage().updateThreshold(threshold_);
 
         emit UpdateThreshold(threshold_);
+    }
+
+    /**
+     * @notice Applies a batch of signer set mutations atomically, validating invariants once at
+     *         the end (see `MultiSignerLib.updateSignerSet`).
+     *
+     * @dev Requires a threshold-signed chainless context.
+     *
+     * @param ops_ Sequential mutations; empty signer = remove at index, else add at index.
+     * @param threshold_ New threshold; 0 keeps the current threshold.
+     */
+    function updateSignerSet(MultiSignerLib.SignerSetOp[] calldata ops_, uint8 threshold_) external onlyAuthorized {
+        _checkChainlessRole(ROLE_THRESHOLD);
+
+        MultiSigner storage $ = _getMultiSignerStorage();
+        $.updateSignerSet(ops_, threshold_);
+
+        emit UpdateSignerSet(ops_, $.getThreshold());
+    }
+
+    /**
+     * @notice Wholesale replaces the signer set, independent of current state.
+     *
+     * @dev Requires an owner-signed chainless context. State independence is what makes recovery
+     *      replayable on chains whose signer sets have drifted.
+     *
+     * @param signers_ The new signer set.
+     * @param threshold_ The new threshold.
+     */
+    function resetSigners(Signer[] calldata signers_, uint8 threshold_) external onlyAuthorized {
+        _checkChainlessRole(ROLE_OWNER);
+
+        _getMultiSignerStorage().resetSigners(signers_, threshold_);
+
+        emit ResetSigners(signers_, threshold_);
     }
 
     /* -------------------------------------------------------------------------- */
@@ -145,6 +209,10 @@ abstract contract MultiSignerAuth {
     /* -------------------------------------------------------------------------- */
 
     function _authorize() internal virtual;
+
+    /// @dev Reverts unless the current execution context carries `role_` (granted during chainless
+    ///      userOp validation). Implemented by the account.
+    function _checkChainlessRole(uint8 role_) internal view virtual;
 
     /// @notice Helper function to get storage reference to the `MultiSignerStorage` struct.
     function _getMultiSignerStorage() internal view returns (MultiSigner storage) {

--- a/packages/smart-vaults/src/utils/MultiSignerAuth.sol
+++ b/packages/smart-vaults/src/utils/MultiSignerAuth.sol
@@ -26,10 +26,10 @@ abstract contract MultiSignerAuth {
         0x3e5431599761dc1a6f375d94085bdcd73bc8fa7c6b3d455d31679f3080214700;
 
     /**
-     * @dev Signer-state roles, granted per chainless userOp by signature verification (see
-     *      SmartVault). Threshold signers mutate the signer set; only the owner may wholesale
-     *      reset it. All signer-state mutations require a chainless context so state stays in
-     *      lockstep across chains.
+     * @dev Signer-state role bit flags, granted per chainless userOp by signature verification
+     *      (see SmartVault). Threshold signers or the owner mutate the signer set; ownership
+     *      actions are owner-only (enforced in the account's `_checkOwner`). All signer-state
+     *      mutations require a chainless context so state stays in lockstep across chains.
      */
     uint8 internal constant ROLE_THRESHOLD = 1;
     uint8 internal constant ROLE_OWNER = 2;
@@ -81,13 +81,6 @@ abstract contract MultiSignerAuth {
      */
     event UpdateSignerSet(MultiSignerLib.SignerSetOp[] ops, uint8 threshold);
 
-    /**
-     * @notice Emitted when the signer set is wholesale replaced.
-     * @param signers The new signer set.
-     * @param threshold The new threshold.
-     */
-    event ResetSigners(Signer[] signers, uint8 threshold);
-
     /* -------------------------------------------------------------------------- */
     /*                                  MODIFIERS                                 */
     /* -------------------------------------------------------------------------- */
@@ -130,7 +123,7 @@ abstract contract MultiSignerAuth {
      * @param index_ The index to register the signer.
      */
     function addSigner(Signer calldata signer_, uint8 index_) external onlyAuthorized {
-        _checkChainlessRole(ROLE_THRESHOLD);
+        _checkChainlessRole(ROLE_THRESHOLD | ROLE_OWNER);
 
         _getMultiSignerStorage().addSigner(signer_, index_);
 
@@ -146,7 +139,7 @@ abstract contract MultiSignerAuth {
      * @param index_ The index of the signer to be removed.
      */
     function removeSigner(uint8 index_) external onlyAuthorized {
-        _checkChainlessRole(ROLE_THRESHOLD);
+        _checkChainlessRole(ROLE_THRESHOLD | ROLE_OWNER);
 
         Signer memory signer = _getMultiSignerStorage().removeSigner(index_);
 
@@ -162,7 +155,7 @@ abstract contract MultiSignerAuth {
      * @param threshold_ The new signer set threshold.
      */
     function updateThreshold(uint8 threshold_) external onlyAuthorized {
-        _checkChainlessRole(ROLE_THRESHOLD);
+        _checkChainlessRole(ROLE_THRESHOLD | ROLE_OWNER);
 
         _getMultiSignerStorage().updateThreshold(threshold_);
 
@@ -173,35 +166,18 @@ abstract contract MultiSignerAuth {
      * @notice Applies a batch of signer set mutations atomically, validating invariants once at
      *         the end (see `MultiSignerLib.updateSignerSet`).
      *
-     * @dev Requires a threshold-signed chainless context.
+     * @dev Requires a chainless context: threshold-signed, or owner-signed (recovery).
      *
      * @param ops_ Sequential mutations; empty signer = remove at index, else add at index.
      * @param threshold_ New threshold; 0 keeps the current threshold.
      */
     function updateSignerSet(MultiSignerLib.SignerSetOp[] calldata ops_, uint8 threshold_) external onlyAuthorized {
-        _checkChainlessRole(ROLE_THRESHOLD);
+        _checkChainlessRole(ROLE_THRESHOLD | ROLE_OWNER);
 
         MultiSigner storage $ = _getMultiSignerStorage();
         $.updateSignerSet(ops_, threshold_);
 
         emit UpdateSignerSet(ops_, $.getThreshold());
-    }
-
-    /**
-     * @notice Wholesale replaces the signer set, independent of current state.
-     *
-     * @dev Requires an owner-signed chainless context. State independence is what makes recovery
-     *      replayable on chains whose signer sets have drifted.
-     *
-     * @param signers_ The new signer set.
-     * @param threshold_ The new threshold.
-     */
-    function resetSigners(Signer[] calldata signers_, uint8 threshold_) external onlyAuthorized {
-        _checkChainlessRole(ROLE_OWNER);
-
-        _getMultiSignerStorage().resetSigners(signers_, threshold_);
-
-        emit ResetSigners(signers_, threshold_);
     }
 
     /* -------------------------------------------------------------------------- */
@@ -210,9 +186,9 @@ abstract contract MultiSignerAuth {
 
     function _authorize() internal virtual;
 
-    /// @dev Reverts unless the current execution context carries `role_` (granted during chainless
-    ///      userOp validation). Implemented by the account.
-    function _checkChainlessRole(uint8 role_) internal view virtual;
+    /// @dev Reverts unless the current execution context carries a role in the `roleMask_` bit
+    ///      mask (granted during chainless userOp validation). Implemented by the account.
+    function _checkChainlessRole(uint8 roleMask_) internal view virtual;
 
     /// @notice Helper function to get storage reference to the `MultiSignerStorage` struct.
     function _getMultiSignerStorage() internal view returns (MultiSigner storage) {

--- a/packages/smart-vaults/src/vault/SmartVault.sol
+++ b/packages/smart-vaults/src/vault/SmartVault.sol
@@ -452,9 +452,9 @@ contract SmartVault is IAccount, Ownable, UUPSUpgradeable, MultiSignerAuth, ERC1
         revert Unauthorized();
     }
 
-    /// @dev Reverts unless the live chainless context carries `role_`.
-    function _checkChainlessRole(uint8 role_) internal view override {
-        if (uint8(_getChainlessCtx()) != role_) revert InvalidChainlessContext();
+    /// @dev Reverts unless the live chainless context carries a role in `roleMask_`.
+    function _checkChainlessRole(uint8 roleMask_) internal view override {
+        if (uint8(_getChainlessCtx()) & roleMask_ == 0) revert InvalidChainlessContext();
     }
 
     /**

--- a/packages/smart-vaults/src/vault/SmartVault.sol
+++ b/packages/smart-vaults/src/vault/SmartVault.sol
@@ -13,6 +13,7 @@ import { MerkleProof } from "@openzeppelin/contracts/utils/cryptography/MerklePr
 import { IAccount } from "account-abstraction/interfaces/IAccount.sol";
 import { PackedUserOperation } from "account-abstraction/interfaces/PackedUserOperation.sol";
 import { Ownable } from "solady/auth/Ownable.sol";
+import { SignatureCheckerLib } from "solady/utils/SignatureCheckerLib.sol";
 import { UUPSUpgradeable } from "solady/utils/UUPSUpgradeable.sol";
 
 /**
@@ -32,7 +33,8 @@ contract SmartVault is IAccount, Ownable, UUPSUpgradeable, MultiSignerAuth, ERC1
     enum SignatureTypes {
         SingleUserOp,
         MerkelizedUserOp,
-        ERC1271
+        ERC1271,
+        ChainlessUserOp
     }
 
     /// @notice Upper limits for maxPriorityFeePerGas, preVerificationGas, verificationGasLimit, callGasLimit,
@@ -85,12 +87,48 @@ contract SmartVault is IAccount, Ownable, UUPSUpgradeable, MultiSignerAuth, ERC1
         MultiSignerLib.SignatureWrapper[] signatures;
     }
 
+    /**
+     * @notice Chainless User Op Signature Scheme. Signed over the chainless hash (no chainId, no
+     *         EntryPoint nonce, no gas limits, no time bounds) so one signature replays on every
+     *         chain, keeping account state in lockstep.
+     */
+    struct ChainlessUserOpSignature {
+        /// @notice The account's chainless nonce this op consumes (sequential, vault storage).
+        uint256 nonce;
+        /// @notice If true, `ownerSignature` is verified against `owner()`; else `signatures`
+        /// against the signer set.
+        bool viaOwner;
+        /// @notice Owner signature over the chainless hash (ECDSA or ERC-1271, incl. 7702).
+        bytes ownerSignature;
+        /// @notice Threshold signatures over the chainless hash. All signers sign the same hash;
+        /// no light hash exists because gas is unsigned (and unpaid).
+        MultiSignerLib.SignatureWrapper[] signatures;
+    }
+
     /* -------------------------------------------------------------------------- */
     /*                                  CONSTANTS                                 */
     /* -------------------------------------------------------------------------- */
 
     /// @notice Splits smart vaults factory.
     address public immutable FACTORY;
+
+    /// @notice EIP-712 typehash for the chainless userOp digest.
+    bytes32 private constant _CHAINLESS_USER_OP_TYPEHASH =
+        keccak256("ChainlessUserOp(uint256 nonce,bytes32 callDataHash,address entryPoint)");
+
+    /// @dev Slot for the sequential chainless nonce: keccak256("splits.spike.chainlessNonce").
+    bytes32 private constant _CHAINLESS_NONCE_SLOT = 0xbf84fbe07ee46584cb00ca9dc247f1cc834d70e536df2ef0199eff397652abeb;
+
+    /**
+     * @dev Slot for the chainless execution context: keccak256("splits.spike.chainlessCtx").
+     *      Packed as `(chainlessNonce << 8) | role`. Written during validation once the chainless
+     *      signature verifies, consumed and cleared by `executeChainless`. The nonce in the
+     *      packing makes two chainless ops for this account in one bundle fail closed instead of
+     *      leaking the second op's role to the first op's execution.
+     *      ponytail: plain storage because solc is pinned to 0.8.23/shanghai — transient storage
+     *      once the toolchain moves to cancun.
+     */
+    bytes32 private constant _CHAINLESS_CTX_SLOT = 0xa376dc2f3bf9f2889ab135e26e6fcd0514f9576ec68e5f2a682d95ca957ade32;
 
     /* -------------------------------------------------------------------------- */
     /*                                   ERRORS                                   */
@@ -116,6 +154,18 @@ contract SmartVault is IAccount, Ownable, UUPSUpgradeable, MultiSignerAuth, ERC1
 
     /// @notice Thrown when Paymaster LightUserOpGasLimits have been breached.
     error InvalidPaymasterData();
+
+    /// @notice Thrown when a chainless userOp violates its structural constraints (non-zero gas
+    /// price, paymaster present, callData not executeChainless, call not a zero-value self-call,
+    /// or nonce mismatch between callData and signature).
+    error InvalidChainlessUserOp();
+
+    /// @notice Thrown when a chainless userOp's nonce is not the account's current chainless nonce.
+    error InvalidChainlessNonce(uint256 expected, uint256 actual);
+
+    /// @notice Thrown when a signer-state function is called outside a chainless execution context
+    /// carrying the required role.
+    error InvalidChainlessContext();
 
     /* -------------------------------------------------------------------------- */
     /*                                  MODIFIERS                                 */
@@ -261,9 +311,30 @@ contract SmartVault is IAccount, Ownable, UUPSUpgradeable, MultiSignerAuth, ERC1
             }
 
             return _validateMerkelizedUserOp(lightHash, userOpHash_, signature);
+        } else if (signatureType == SignatureTypes.ChainlessUserOp) {
+            return _validateChainlessUserOp(userOp_);
         } else {
             revert InvalidSignatureType();
         }
+    }
+
+    /**
+     * @notice Executes a chainless userOp's calls. Only reachable as the callData of a validated
+     *         ChainlessUserOp (enforced via the context written during validation).
+     *
+     * @param nonce_ The chainless nonce this op consumed; must match the stored context.
+     * @param calls_ Zero-value calls to this account (enforced during validation).
+     */
+    function executeChainless(uint256 nonce_, Call[] calldata calls_) external payable onlyEntryPoint {
+        uint256 ctx = _getChainlessCtx();
+        if (ctx >> 8 != nonce_ || uint8(ctx) == 0) revert InvalidChainlessContext();
+
+        uint256 numCalls = calls_.length;
+        for (uint256 i; i < numCalls; i++) {
+            _call(calls_[i]);
+        }
+
+        _setChainlessCtx(0);
     }
 
     /**
@@ -294,6 +365,25 @@ contract SmartVault is IAccount, Ownable, UUPSUpgradeable, MultiSignerAuth, ERC1
     /// @notice Returns the address of the EntryPoint v0.7.
     function entryPoint() public view virtual returns (address) {
         return 0x0000000071727De22E5E9d8BAf0edAc6f37da032;
+    }
+
+    /// @notice Returns the account's current chainless nonce.
+    function getChainlessNonce() public view returns (uint256 nonce) {
+        assembly ("memory-safe") {
+            nonce := sload(_CHAINLESS_NONCE_SLOT)
+        }
+    }
+
+    /**
+     * @notice Chainless userOp digest that signers (or the owner) sign.
+     *
+     * @dev Binds the chainless nonce, callData and EntryPoint under the chainless EIP-712 domain
+     *      (no chainId). Deliberately excludes the EntryPoint nonce, gas limits and time bounds.
+     */
+    function getChainlessUserOpHash(uint256 nonce_, bytes calldata callData_) public view returns (bytes32) {
+        return _hashChainlessTypedData(
+            keccak256(abi.encode(_CHAINLESS_USER_OP_TYPEHASH, nonce_, keccak256(callData_), entryPoint()))
+        );
     }
 
     /**
@@ -345,6 +435,9 @@ contract SmartVault is IAccount, Ownable, UUPSUpgradeable, MultiSignerAuth, ERC1
      * @dev Conditions for a valid owner check:
      *      if owner is non zero, caller must be owner.
      *      If owner is address(0), contract can call itself.
+     *      Self-calls inside an owner-signed chainless op count as the owner (this is what lets a
+     *      vault owner authorize ownership changes — and upgrades — by signature, replayable on
+     *      every chain).
      */
     function _checkOwner() internal view override {
         address owner;
@@ -355,8 +448,73 @@ contract SmartVault is IAccount, Ownable, UUPSUpgradeable, MultiSignerAuth, ERC1
         }
 
         if (owner == caller) return;
-        if (owner == address(0) && caller == address(this)) return;
+        if (caller == address(this) && (owner == address(0) || uint8(_getChainlessCtx()) == ROLE_OWNER)) return;
         revert Unauthorized();
+    }
+
+    /// @dev Reverts unless the live chainless context carries `role_`.
+    function _checkChainlessRole(uint8 role_) internal view override {
+        if (uint8(_getChainlessCtx()) != role_) revert InvalidChainlessContext();
+    }
+
+    /**
+     * @dev Validates a chainless userOp: structural constraints, sequential nonce, then signature
+     *      over the chainless digest. On success, records the role context consumed by
+     *      `executeChainless`.
+     */
+    function _validateChainlessUserOp(PackedUserOperation calldata userOp_) internal returns (uint256) {
+        ChainlessUserOpSignature memory signature = abi.decode(userOp_.signature[1:], (ChainlessUserOpSignature));
+
+        // Zero gas price and no paymaster: replaying a chainless op must never cost the account
+        // anything, else old signatures become a gas-griefing vector on every chain.
+        if (userOp_.gasFees != bytes32(0) || userOp_.paymasterAndData.length != 0) {
+            revert InvalidChainlessUserOp();
+        }
+
+        // callData must be executeChainless(nonce, calls) where every call is a zero-value
+        // self-call: state sync only, asset movement structurally impossible.
+        if (bytes4(userOp_.callData[0:4]) != this.executeChainless.selector) revert InvalidChainlessUserOp();
+        (uint256 callDataNonce, Call[] memory calls) = abi.decode(userOp_.callData[4:], (uint256, Call[]));
+        if (callDataNonce != signature.nonce) revert InvalidChainlessUserOp();
+
+        uint256 numCalls = calls.length;
+        for (uint256 i; i < numCalls; i++) {
+            if (calls[i].target != address(this) || calls[i].value != 0) revert InvalidChainlessUserOp();
+        }
+
+        uint256 nonce = getChainlessNonce();
+        if (signature.nonce != nonce) revert InvalidChainlessNonce(nonce, signature.nonce);
+        _setChainlessNonce(nonce + 1);
+
+        bytes32 hash = getChainlessUserOpHash(signature.nonce, userOp_.callData);
+
+        bool isValid = signature.viaOwner
+            ? SignatureCheckerLib.isValidSignatureNow(owner(), hash, signature.ownerSignature)
+            : _getMultiSignerStorage().isValidSignature(hash, signature.signatures);
+
+        if (!isValid) return UserOperationLib.INVALID_SIGNATURE;
+
+        _setChainlessCtx((signature.nonce << 8) | (signature.viaOwner ? ROLE_OWNER : ROLE_THRESHOLD));
+
+        return UserOperationLib.VALID_SIGNATURE;
+    }
+
+    function _getChainlessCtx() internal view returns (uint256 ctx) {
+        assembly ("memory-safe") {
+            ctx := sload(_CHAINLESS_CTX_SLOT)
+        }
+    }
+
+    function _setChainlessCtx(uint256 ctx_) internal {
+        assembly ("memory-safe") {
+            sstore(_CHAINLESS_CTX_SLOT, ctx_)
+        }
+    }
+
+    function _setChainlessNonce(uint256 nonce_) internal {
+        assembly ("memory-safe") {
+            sstore(_CHAINLESS_NONCE_SLOT, nonce_)
+        }
     }
 
     /// @dev Get light userOp hash of the Packed user operation.

--- a/packages/smart-vaults/test/ChainlessUserOp.t.sol
+++ b/packages/smart-vaults/test/ChainlessUserOp.t.sol
@@ -1,0 +1,513 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { BaseTest, createSigner } from "./Base.t.sol";
+
+import { EntryPoint } from "account-abstraction/core/EntryPoint.sol";
+import { PackedUserOperation } from "account-abstraction/interfaces/PackedUserOperation.sol";
+import { SignatureCheckerLib } from "solady/utils/SignatureCheckerLib.sol";
+
+import { MultiSignerLib } from "src/signers/MultiSigner.sol";
+import { Signer } from "src/signers/Signer.sol";
+import { Caller } from "src/utils/Caller.sol";
+import { MultiSignerAuth } from "src/utils/MultiSignerAuth.sol";
+import { SmartVault } from "src/vault/SmartVault.sol";
+
+import { console2 } from "forge-std/console2.sol";
+
+/// @notice Spike tests: one signature validates and executes a state update on any chain.
+contract ChainlessUserOpTest is BaseTest {
+    address constant ENTRY_POINT = 0x0000000071727De22E5E9d8BAf0edAc6f37da032;
+    bytes32 constant CTX_SLOT = 0xa376dc2f3bf9f2889ab135e26e6fcd0514f9576ec68e5f2a682d95ca957ade32;
+
+    uint256 constant CHAIN_A = 31_337;
+    uint256 constant CHAIN_B = 8453;
+
+    EntryPoint entryPoint;
+
+    /// @dev 2-of-2 vault (ALICE, BOB), owned by CAROL's EOA.
+    SmartVault vault;
+
+    /// @dev 1-of-1 vault (CAROL) acting as owner of `ownedVault` — the recovery composition.
+    SmartVault ownerVault;
+    SmartVault ownedVault;
+
+    function setUp() public override {
+        super.setUp();
+
+        EntryPoint deployed = new EntryPoint();
+        vm.etch(ENTRY_POINT, address(deployed).code);
+        entryPoint = EntryPoint(payable(ENTRY_POINT));
+
+        Signer[] memory signers = new Signer[](2);
+        signers[0] = createSigner(ALICE.addr);
+        signers[1] = createSigner(BOB.addr);
+        vault = smartVaultFactory.createAccount(CAROL.addr, signers, 2, 0);
+
+        Signer[] memory ownerSigners = new Signer[](1);
+        ownerSigners[0] = createSigner(CAROL.addr);
+        ownerVault = smartVaultFactory.createAccount(CAROL.addr, ownerSigners, 1, 1);
+
+        Signer[] memory ownedSigners = new Signer[](1);
+        ownedSigners[0] = createSigner(ALICE.addr);
+        ownedVault = smartVaultFactory.createAccount(address(ownerVault), ownedSigners, 1, 2);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                   HELPERS                                  */
+    /* -------------------------------------------------------------------------- */
+
+    function _chainlessUserOp(
+        SmartVault vault_,
+        uint256 chainlessNonce_,
+        Caller.Call[] memory calls_
+    )
+        internal
+        view
+        returns (PackedUserOperation memory op)
+    {
+        op.sender = address(vault_);
+        op.nonce = entryPoint.getNonce(address(vault_), 0);
+        op.initCode = "";
+        op.callData = abi.encodeWithSelector(SmartVault.executeChainless.selector, chainlessNonce_, calls_);
+        // verificationGasLimit | callGasLimit. Call limit is generous: the resetSigners 256-slot
+        // scan alone costs ~1M gas (spike finding).
+        op.accountGasLimits = bytes32((uint256(2_000_000) << 128) | 4_000_000);
+        op.preVerificationGas = 100_000;
+        op.gasFees = bytes32(0); // zero gas price: required by the chainless validation rules
+        op.paymasterAndData = "";
+        op.signature = "";
+    }
+
+    function _thresholdSig(
+        SmartVault vault_,
+        uint256 chainlessNonce_,
+        bytes memory callData_,
+        Account[2] memory signers_
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 hash = vault_.getChainlessUserOpHash(chainlessNonce_, callData_);
+
+        MultiSignerLib.SignatureWrapper[] memory sigs = new MultiSignerLib.SignatureWrapper[](2);
+        for (uint256 i; i < 2; i++) {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(signers_[i].key, SignatureCheckerLib.toEthSignedMessageHash(hash));
+            sigs[i] = MultiSignerLib.SignatureWrapper(uint8(i), abi.encodePacked(r, s, v));
+        }
+
+        return _encodeChainlessSig(SmartVault.ChainlessUserOpSignature(chainlessNonce_, false, "", sigs));
+    }
+
+    function _ownerEOASig(
+        SmartVault vault_,
+        uint256 chainlessNonce_,
+        bytes memory callData_,
+        Account memory owner_
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 hash = vault_.getChainlessUserOpHash(chainlessNonce_, callData_);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(owner_.key, hash);
+
+        return _encodeChainlessSig(
+            SmartVault.ChainlessUserOpSignature(
+                chainlessNonce_, true, abi.encodePacked(r, s, v), new MultiSignerLib.SignatureWrapper[](0)
+            )
+        );
+    }
+
+    /// @dev Owner is a vault: its signer signs the owned vault's chainless hash through the owner
+    ///      vault's CHAINLESS 1271 domain. This is the recovery composition — if the owner vault
+    ///      wrapped with its chain-bound domain instead, the signature would pin to one chain.
+    function _ownerVaultSig(
+        SmartVault vault_,
+        uint256 chainlessNonce_,
+        bytes memory callData_,
+        SmartVault ownerVault_,
+        Account memory ownerVaultSigner_
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 hash = vault_.getChainlessUserOpHash(chainlessNonce_, callData_);
+        bytes32 ownerDigest = ownerVault_.chainlessReplaySafeHash(hash);
+
+        (uint8 v, bytes32 r, bytes32 s) =
+            vm.sign(ownerVaultSigner_.key, SignatureCheckerLib.toEthSignedMessageHash(ownerDigest));
+
+        MultiSignerLib.SignatureWrapper[] memory sigs = new MultiSignerLib.SignatureWrapper[](1);
+        sigs[0] = MultiSignerLib.SignatureWrapper(uint8(0), abi.encodePacked(r, s, v));
+
+        // 0x01 = chainless 1271 domain discriminator
+        bytes memory ownerSig = abi.encodePacked(bytes1(0x01), abi.encode(SmartVault.ERC1271Signature(sigs)));
+
+        return _encodeChainlessSig(
+            SmartVault.ChainlessUserOpSignature(
+                chainlessNonce_, true, ownerSig, new MultiSignerLib.SignatureWrapper[](0)
+            )
+        );
+    }
+
+    function _encodeChainlessSig(SmartVault.ChainlessUserOpSignature memory sig_) internal pure returns (bytes memory) {
+        return abi.encodePacked(bytes1(uint8(SmartVault.SignatureTypes.ChainlessUserOp)), abi.encode(sig_));
+    }
+
+    function _handleOps(PackedUserOperation memory op_) internal {
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = op_;
+        entryPoint.handleOps(ops, payable(DAN.addr));
+    }
+
+    function _updateSignerSetCall(
+        SmartVault vault_,
+        MultiSignerLib.SignerSetOp[] memory ops_,
+        uint8 threshold_
+    )
+        internal
+        pure
+        returns (Caller.Call[] memory calls)
+    {
+        calls = new Caller.Call[](1);
+        calls[0] = Caller.Call(
+            address(vault_), 0, abi.encodeWithSelector(MultiSignerAuth.updateSignerSet.selector, ops_, threshold_)
+        );
+    }
+
+    function _resetSignersCall(
+        SmartVault vault_,
+        Signer[] memory signers_,
+        uint8 threshold_
+    )
+        internal
+        pure
+        returns (Caller.Call[] memory calls)
+    {
+        calls = new Caller.Call[](1);
+        calls[0] = Caller.Call(
+            address(vault_), 0, abi.encodeWithSelector(MultiSignerAuth.resetSigners.selector, signers_, threshold_)
+        );
+    }
+
+    function _assertCtxCleared(SmartVault vault_) internal view {
+        assertEq(uint256(vm.load(address(vault_), CTX_SLOT)), 0, "ctx not cleared");
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                        CROSS-CHAIN REPLAY (THE POINT)                       */
+    /* -------------------------------------------------------------------------- */
+
+    /// @notice One threshold-signed op — add DAN, raise threshold to 3 — executes identically on
+    ///         two chains.
+    function test_chainlessReplay_thresholdSigners_acrossChains() public {
+        MultiSignerLib.SignerSetOp[] memory ops = new MultiSignerLib.SignerSetOp[](1);
+        ops[0] = MultiSignerLib.SignerSetOp(2, createSigner(DAN.addr));
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 0, _updateSignerSetCall(vault, ops, 3));
+        op.signature = _thresholdSig(vault, 0, op.callData, [ALICE, BOB]);
+
+        uint256 snapshot = vm.snapshot();
+
+        uint256 gasBefore = gasleft();
+        _handleOps(op);
+        console2.log("handleOps gas (threshold chainless updateSignerSet):", gasBefore - gasleft());
+
+        assertEq(vault.getSigner(2), createSigner(DAN.addr));
+        assertEq(vault.getThreshold(), 3);
+        assertEq(vault.getSignerCount(), 3);
+        assertEq(vault.getChainlessNonce(), 1);
+        _assertCtxCleared(vault);
+
+        // Chain B: identical bytes, fresh state, different chainId.
+        vm.revertTo(snapshot);
+        vm.chainId(CHAIN_B);
+        assertEq(vault.getSignerCount(), 2, "snapshot revert failed");
+
+        _handleOps(op);
+
+        assertEq(vault.getSigner(2), createSigner(DAN.addr));
+        assertEq(vault.getThreshold(), 3);
+        assertEq(vault.getChainlessNonce(), 1);
+        _assertCtxCleared(vault);
+    }
+
+    /// @notice The 2-of-2 signer swap that requires temp-signer gymnastics today: remove BOB and
+    ///         install DAN at his slot in a single atomic call.
+    function test_chainless_atomic2of2Swap() public {
+        MultiSignerLib.SignerSetOp[] memory ops = new MultiSignerLib.SignerSetOp[](2);
+        ops[0] = MultiSignerLib.SignerSetOp(1, Signer(0, 0)); // remove BOB
+        ops[1] = MultiSignerLib.SignerSetOp(1, createSigner(DAN.addr)); // add DAN at slot 1
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 0, _updateSignerSetCall(vault, ops, 0));
+        op.signature = _thresholdSig(vault, 0, op.callData, [ALICE, BOB]);
+
+        _handleOps(op);
+
+        assertEq(vault.getSigner(1), createSigner(DAN.addr));
+        assertEq(vault.getThreshold(), 2);
+        assertEq(vault.getSignerCount(), 2);
+    }
+
+    /// @notice Owner (EOA) resets the signer set and hands off ownership in one chainless op,
+    ///         replayed on two chains.
+    function test_chainlessReplay_ownerEOA_resetAndTransferOwnership() public {
+        Signer[] memory newSigners = new Signer[](1);
+        newSigners[0] = createSigner(DAN.addr);
+
+        Caller.Call[] memory calls = new Caller.Call[](2);
+        calls[0] = _resetSignersCall(vault, newSigners, 1)[0];
+        calls[1] = Caller.Call(address(vault), 0, abi.encodeWithSignature("transferOwnership(address)", DAN.addr));
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 0, calls);
+        op.signature = _ownerEOASig(vault, 0, op.callData, CAROL);
+
+        uint256 snapshot = vm.snapshot();
+
+        uint256 gasBefore = gasleft();
+        _handleOps(op);
+        console2.log("handleOps gas (owner reset incl. 256-slot scan):", gasBefore - gasleft());
+
+        assertEq(vault.getSigner(0), createSigner(DAN.addr));
+        assertEq(vault.getSignerCount(), 1);
+        assertEq(vault.getThreshold(), 1);
+        assertEq(vault.owner(), DAN.addr);
+        _assertCtxCleared(vault);
+
+        vm.revertTo(snapshot);
+        vm.chainId(CHAIN_B);
+
+        _handleOps(op);
+
+        assertEq(vault.getSigner(0), createSigner(DAN.addr));
+        assertEq(vault.owner(), DAN.addr);
+    }
+
+    /// @notice The recovery composition: the owner is itself a vault, signing through its
+    ///         chainless 1271 domain. One signature by the owner vault's signer recovers the owned
+    ///         vault on two chains.
+    function test_chainlessReplay_ownerVault_chainless1271() public {
+        Signer[] memory newSigners = new Signer[](1);
+        newSigners[0] = createSigner(DAN.addr);
+
+        PackedUserOperation memory op = _chainlessUserOp(ownedVault, 0, _resetSignersCall(ownedVault, newSigners, 1));
+        op.signature = _ownerVaultSig(ownedVault, 0, op.callData, ownerVault, CAROL);
+
+        uint256 snapshot = vm.snapshot();
+
+        _handleOps(op);
+        assertEq(ownedVault.getSigner(0), createSigner(DAN.addr));
+        assertEq(ownedVault.getSignerCount(), 1);
+
+        vm.revertTo(snapshot);
+        vm.chainId(CHAIN_B);
+
+        _handleOps(op);
+        assertEq(ownedVault.getSigner(0), createSigner(DAN.addr));
+        assertEq(ownedVault.getSignerCount(), 1);
+    }
+
+    /// @notice Owner reset replays correctly on a chain whose signer state has drifted — reset is
+    ///         state-independent, which is what makes it the recovery/migration baseline.
+    function test_chainlessReplay_reset_onDriftedChain() public {
+        Signer[] memory newSigners = new Signer[](1);
+        newSigners[0] = createSigner(DAN.addr);
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 0, _resetSignersCall(vault, newSigners, 1));
+        op.signature = _ownerEOASig(vault, 0, op.callData, CAROL);
+
+        uint256 snapshot = vm.snapshot();
+        _handleOps(op);
+        assertEq(vault.getSignerCount(), 1);
+
+        // Chain B drifted: an extra signer at a high slot (simulating pre-chainless legacy state).
+        vm.revertTo(snapshot);
+        vm.chainId(CHAIN_B);
+        vm.store(address(vault), CTX_SLOT, bytes32(uint256(1))); // grant ctx for legacy add
+        vm.prank(address(vault));
+        vault.addSigner(createSigner(CAROL.addr), 200);
+        vm.store(address(vault), CTX_SLOT, bytes32(0));
+        assertEq(vault.getSignerCount(), 3);
+
+        _handleOps(op);
+
+        assertEq(vault.getSigner(0), createSigner(DAN.addr));
+        assertEq(vault.getSigner(200), Signer(0, 0));
+        assertEq(vault.getSignerCount(), 1);
+        assertEq(vault.getThreshold(), 1);
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                                  NEGATIVES                                 */
+    /* -------------------------------------------------------------------------- */
+
+    function test_chainless_replayOnSameChain_reverts() public {
+        MultiSignerLib.SignerSetOp[] memory ops = new MultiSignerLib.SignerSetOp[](1);
+        ops[0] = MultiSignerLib.SignerSetOp(2, createSigner(DAN.addr));
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 0, _updateSignerSetCall(vault, ops, 0));
+        op.signature = _thresholdSig(vault, 0, op.callData, [ALICE, BOB]);
+
+        _handleOps(op);
+        assertEq(vault.getChainlessNonce(), 1);
+
+        // Same op again on the same chain: chainless nonce already consumed.
+        op.nonce = entryPoint.getNonce(address(vault), 0);
+        vm.expectRevert(); // FailedOp(AA23 reverted) wrapping InvalidChainlessNonce
+        _handleOps(op);
+    }
+
+    function test_chainless_outOfOrderNonce_reverts() public {
+        MultiSignerLib.SignerSetOp[] memory ops = new MultiSignerLib.SignerSetOp[](1);
+        ops[0] = MultiSignerLib.SignerSetOp(2, createSigner(DAN.addr));
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 1, _updateSignerSetCall(vault, ops, 0));
+        op.signature = _thresholdSig(vault, 1, op.callData, [ALICE, BOB]);
+
+        vm.prank(ENTRY_POINT);
+        vm.expectRevert(abi.encodeWithSelector(SmartVault.InvalidChainlessNonce.selector, 0, 1));
+        vault.validateUserOp(op, bytes32(0), 0);
+    }
+
+    function test_chainless_nonZeroGasFees_reverts() public {
+        PackedUserOperation memory op = _buildValidThresholdOp();
+        op.gasFees = bytes32(uint256(1));
+
+        vm.prank(ENTRY_POINT);
+        vm.expectRevert(SmartVault.InvalidChainlessUserOp.selector);
+        vault.validateUserOp(op, bytes32(0), 0);
+    }
+
+    function test_chainless_paymasterSet_reverts() public {
+        PackedUserOperation memory op = _buildValidThresholdOp();
+        op.paymasterAndData = abi.encodePacked(address(1), uint128(1), uint128(1));
+
+        vm.prank(ENTRY_POINT);
+        vm.expectRevert(SmartVault.InvalidChainlessUserOp.selector);
+        vault.validateUserOp(op, bytes32(0), 0);
+    }
+
+    function test_chainless_callDataNotExecuteChainless_reverts() public {
+        PackedUserOperation memory op = _buildValidThresholdOp();
+        op.callData = abi.encodeWithSelector(SmartVault.execute.selector, Caller.Call(address(vault), 0, ""));
+
+        vm.prank(ENTRY_POINT);
+        vm.expectRevert(SmartVault.InvalidChainlessUserOp.selector);
+        vault.validateUserOp(op, bytes32(0), 0);
+    }
+
+    function test_chainless_externalTarget_reverts() public {
+        Caller.Call[] memory calls = new Caller.Call[](1);
+        calls[0] = Caller.Call(DAN.addr, 0, "");
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 0, calls);
+        op.signature = _thresholdSig(vault, 0, op.callData, [ALICE, BOB]);
+
+        vm.prank(ENTRY_POINT);
+        vm.expectRevert(SmartVault.InvalidChainlessUserOp.selector);
+        vault.validateUserOp(op, bytes32(0), 0);
+    }
+
+    function test_chainless_nonZeroValue_reverts() public {
+        Caller.Call[] memory calls = new Caller.Call[](1);
+        calls[0] = Caller.Call(address(vault), 1, "");
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 0, calls);
+        op.signature = _thresholdSig(vault, 0, op.callData, [ALICE, BOB]);
+
+        vm.prank(ENTRY_POINT);
+        vm.expectRevert(SmartVault.InvalidChainlessUserOp.selector);
+        vault.validateUserOp(op, bytes32(0), 0);
+    }
+
+    function test_chainless_callDataNonceMismatch_reverts() public {
+        MultiSignerLib.SignerSetOp[] memory ops = new MultiSignerLib.SignerSetOp[](1);
+        ops[0] = MultiSignerLib.SignerSetOp(2, createSigner(DAN.addr));
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 5, _updateSignerSetCall(vault, ops, 0));
+        // signature claims nonce 0, callData says 5
+        op.signature = _thresholdSig(vault, 0, op.callData, [ALICE, BOB]);
+
+        vm.prank(ENTRY_POINT);
+        vm.expectRevert(SmartVault.InvalidChainlessUserOp.selector);
+        vault.validateUserOp(op, bytes32(0), 0);
+    }
+
+    /// @notice A wrong-hash signature (e.g. signed under a chain-bound scheme) fails soft with
+    ///         SIG_VALIDATION_FAILED, per 4337.
+    function test_chainless_wrongDomainSignature_invalid() public {
+        MultiSignerLib.SignerSetOp[] memory ops = new MultiSignerLib.SignerSetOp[](1);
+        ops[0] = MultiSignerLib.SignerSetOp(2, createSigner(DAN.addr));
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 0, _updateSignerSetCall(vault, ops, 0));
+
+        // Sign the CHAIN-BOUND wrap of the chainless struct hash instead of the chainless digest.
+        bytes32 wrongHash = vault.replaySafeHash(keccak256(op.callData));
+        MultiSignerLib.SignatureWrapper[] memory sigs = new MultiSignerLib.SignatureWrapper[](2);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ALICE.key, SignatureCheckerLib.toEthSignedMessageHash(wrongHash));
+        sigs[0] = MultiSignerLib.SignatureWrapper(0, abi.encodePacked(r, s, v));
+        (v, r, s) = vm.sign(BOB.key, SignatureCheckerLib.toEthSignedMessageHash(wrongHash));
+        sigs[1] = MultiSignerLib.SignatureWrapper(1, abi.encodePacked(r, s, v));
+        op.signature = _encodeChainlessSig(SmartVault.ChainlessUserOpSignature(0, false, "", sigs));
+
+        vm.prank(ENTRY_POINT);
+        assertEq(vault.validateUserOp(op, bytes32(0), 0), 1);
+    }
+
+    /// @notice Threshold signers cannot smuggle owner-only actions: validation passes (their
+    ///         signature is genuine) but execution hits the role gate and the op's calls revert.
+    function test_chainless_thresholdCannotReset_roleGate() public {
+        Signer[] memory newSigners = new Signer[](1);
+        newSigners[0] = createSigner(DAN.addr);
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 0, _resetSignersCall(vault, newSigners, 1));
+        op.signature = _thresholdSig(vault, 0, op.callData, [ALICE, BOB]);
+
+        _handleOps(op); // does not revert: the op fails post-validation, EntryPoint logs it
+
+        // signer set untouched, nonce consumed
+        assertEq(vault.getSigner(0), createSigner(ALICE.addr));
+        assertEq(vault.getSigner(1), createSigner(BOB.addr));
+        assertEq(vault.getSignerCount(), 2);
+        assertEq(vault.getChainlessNonce(), 1);
+    }
+
+    /// @notice executeChainless is unreachable outside a validated chainless op.
+    function test_executeChainless_withoutValidation_reverts() public {
+        Caller.Call[] memory calls = new Caller.Call[](0);
+
+        vm.prank(ENTRY_POINT);
+        vm.expectRevert(SmartVault.InvalidChainlessContext.selector);
+        vault.executeChainless(0, calls);
+    }
+
+    /// @notice Batch invariants validated once at the end: a batch ending with threshold > count
+    ///         reverts as a whole.
+    function test_updateSignerSet_invalidEndState_reverts() public {
+        MultiSignerLib.SignerSetOp[] memory ops = new MultiSignerLib.SignerSetOp[](1);
+        ops[0] = MultiSignerLib.SignerSetOp(1, Signer(0, 0)); // remove BOB -> count 1, threshold 2
+
+        PackedUserOperation memory op = _chainlessUserOp(vault, 0, _updateSignerSetCall(vault, ops, 0));
+        op.signature = _thresholdSig(vault, 0, op.callData, [ALICE, BOB]);
+
+        _handleOps(op); // op fails post-validation
+
+        assertEq(vault.getSignerCount(), 2, "batch should have reverted atomically");
+        assertEq(vault.getSigner(1), createSigner(BOB.addr));
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                              INTERNAL HELPERS                              */
+    /* -------------------------------------------------------------------------- */
+
+    function _buildValidThresholdOp() internal view returns (PackedUserOperation memory op) {
+        MultiSignerLib.SignerSetOp[] memory ops = new MultiSignerLib.SignerSetOp[](1);
+        ops[0] = MultiSignerLib.SignerSetOp(2, createSigner(DAN.addr));
+
+        op = _chainlessUserOp(vault, 0, _updateSignerSetCall(vault, ops, 0));
+        op.signature = _thresholdSig(vault, 0, op.callData, [ALICE, BOB]);
+    }
+}

--- a/packages/smart-vaults/test/ChainlessUserOp.t.sol
+++ b/packages/smart-vaults/test/ChainlessUserOp.t.sol
@@ -70,8 +70,7 @@ contract ChainlessUserOpTest is BaseTest {
         op.nonce = entryPoint.getNonce(address(vault_), 0);
         op.initCode = "";
         op.callData = abi.encodeWithSelector(SmartVault.executeChainless.selector, chainlessNonce_, calls_);
-        // verificationGasLimit | callGasLimit. Call limit is generous: the resetSigners 256-slot
-        // scan alone costs ~1M gas (spike finding).
+        // verificationGasLimit | callGasLimit
         op.accountGasLimits = bytes32((uint256(2_000_000) << 128) | 4_000_000);
         op.preVerificationGas = 100_000;
         op.gasFees = bytes32(0); // zero gas price: required by the chainless validation rules
@@ -178,21 +177,6 @@ contract ChainlessUserOpTest is BaseTest {
         );
     }
 
-    function _resetSignersCall(
-        SmartVault vault_,
-        Signer[] memory signers_,
-        uint8 threshold_
-    )
-        internal
-        pure
-        returns (Caller.Call[] memory calls)
-    {
-        calls = new Caller.Call[](1);
-        calls[0] = Caller.Call(
-            address(vault_), 0, abi.encodeWithSelector(MultiSignerAuth.resetSigners.selector, signers_, threshold_)
-        );
-    }
-
     function _assertCtxCleared(SmartVault vault_) internal view {
         assertEq(uint256(vm.load(address(vault_), CTX_SLOT)), 0, "ctx not cleared");
     }
@@ -252,14 +236,16 @@ contract ChainlessUserOpTest is BaseTest {
         assertEq(vault.getSignerCount(), 2);
     }
 
-    /// @notice Owner (EOA) resets the signer set and hands off ownership in one chainless op,
-    ///         replayed on two chains.
-    function test_chainlessReplay_ownerEOA_resetAndTransferOwnership() public {
-        Signer[] memory newSigners = new Signer[](1);
-        newSigners[0] = createSigner(DAN.addr);
+    /// @notice Owner (EOA) recovers the signer set (swap both signers for DAN, threshold 1) and
+    ///         hands off ownership in one chainless op, replayed on two chains.
+    function test_chainlessReplay_ownerEOA_recoverAndTransferOwnership() public {
+        MultiSignerLib.SignerSetOp[] memory ops = new MultiSignerLib.SignerSetOp[](3);
+        ops[0] = MultiSignerLib.SignerSetOp(0, Signer(0, 0)); // remove ALICE
+        ops[1] = MultiSignerLib.SignerSetOp(1, Signer(0, 0)); // remove BOB
+        ops[2] = MultiSignerLib.SignerSetOp(0, createSigner(DAN.addr));
 
         Caller.Call[] memory calls = new Caller.Call[](2);
-        calls[0] = _resetSignersCall(vault, newSigners, 1)[0];
+        calls[0] = _updateSignerSetCall(vault, ops, 1)[0];
         calls[1] = Caller.Call(address(vault), 0, abi.encodeWithSignature("transferOwnership(address)", DAN.addr));
 
         PackedUserOperation memory op = _chainlessUserOp(vault, 0, calls);
@@ -269,7 +255,7 @@ contract ChainlessUserOpTest is BaseTest {
 
         uint256 gasBefore = gasleft();
         _handleOps(op);
-        console2.log("handleOps gas (owner reset incl. 256-slot scan):", gasBefore - gasleft());
+        console2.log("handleOps gas (owner recover via updateSignerSet + transferOwnership):", gasBefore - gasleft());
 
         assertEq(vault.getSigner(0), createSigner(DAN.addr));
         assertEq(vault.getSignerCount(), 1);
@@ -287,13 +273,14 @@ contract ChainlessUserOpTest is BaseTest {
     }
 
     /// @notice The recovery composition: the owner is itself a vault, signing through its
-    ///         chainless 1271 domain. One signature by the owner vault's signer recovers the owned
-    ///         vault on two chains.
+    ///         chainless 1271 domain. One signature by the owner vault's signer swaps the owned
+    ///         vault's signer on two chains.
     function test_chainlessReplay_ownerVault_chainless1271() public {
-        Signer[] memory newSigners = new Signer[](1);
-        newSigners[0] = createSigner(DAN.addr);
+        MultiSignerLib.SignerSetOp[] memory ops = new MultiSignerLib.SignerSetOp[](2);
+        ops[0] = MultiSignerLib.SignerSetOp(0, Signer(0, 0)); // remove ALICE
+        ops[1] = MultiSignerLib.SignerSetOp(0, createSigner(DAN.addr));
 
-        PackedUserOperation memory op = _chainlessUserOp(ownedVault, 0, _resetSignersCall(ownedVault, newSigners, 1));
+        PackedUserOperation memory op = _chainlessUserOp(ownedVault, 0, _updateSignerSetCall(ownedVault, ops, 0));
         op.signature = _ownerVaultSig(ownedVault, 0, op.callData, ownerVault, CAROL);
 
         uint256 snapshot = vm.snapshot();
@@ -308,36 +295,6 @@ contract ChainlessUserOpTest is BaseTest {
         _handleOps(op);
         assertEq(ownedVault.getSigner(0), createSigner(DAN.addr));
         assertEq(ownedVault.getSignerCount(), 1);
-    }
-
-    /// @notice Owner reset replays correctly on a chain whose signer state has drifted — reset is
-    ///         state-independent, which is what makes it the recovery/migration baseline.
-    function test_chainlessReplay_reset_onDriftedChain() public {
-        Signer[] memory newSigners = new Signer[](1);
-        newSigners[0] = createSigner(DAN.addr);
-
-        PackedUserOperation memory op = _chainlessUserOp(vault, 0, _resetSignersCall(vault, newSigners, 1));
-        op.signature = _ownerEOASig(vault, 0, op.callData, CAROL);
-
-        uint256 snapshot = vm.snapshot();
-        _handleOps(op);
-        assertEq(vault.getSignerCount(), 1);
-
-        // Chain B drifted: an extra signer at a high slot (simulating pre-chainless legacy state).
-        vm.revertTo(snapshot);
-        vm.chainId(CHAIN_B);
-        vm.store(address(vault), CTX_SLOT, bytes32(uint256(1))); // grant ctx for legacy add
-        vm.prank(address(vault));
-        vault.addSigner(createSigner(CAROL.addr), 200);
-        vm.store(address(vault), CTX_SLOT, bytes32(0));
-        assertEq(vault.getSignerCount(), 3);
-
-        _handleOps(op);
-
-        assertEq(vault.getSigner(0), createSigner(DAN.addr));
-        assertEq(vault.getSigner(200), Signer(0, 0));
-        assertEq(vault.getSignerCount(), 1);
-        assertEq(vault.getThreshold(), 1);
     }
 
     /* -------------------------------------------------------------------------- */
@@ -458,20 +415,19 @@ contract ChainlessUserOpTest is BaseTest {
     }
 
     /// @notice Threshold signers cannot smuggle owner-only actions: validation passes (their
-    ///         signature is genuine) but execution hits the role gate and the op's calls revert.
-    function test_chainless_thresholdCannotReset_roleGate() public {
-        Signer[] memory newSigners = new Signer[](1);
-        newSigners[0] = createSigner(DAN.addr);
+    ///         signature is genuine) but transferOwnership hits _checkOwner (ctx=THRESHOLD) and
+    ///         the op's calls revert.
+    function test_chainless_thresholdCannotTransferOwnership_roleGate() public {
+        Caller.Call[] memory calls = new Caller.Call[](1);
+        calls[0] = Caller.Call(address(vault), 0, abi.encodeWithSignature("transferOwnership(address)", DAN.addr));
 
-        PackedUserOperation memory op = _chainlessUserOp(vault, 0, _resetSignersCall(vault, newSigners, 1));
+        PackedUserOperation memory op = _chainlessUserOp(vault, 0, calls);
         op.signature = _thresholdSig(vault, 0, op.callData, [ALICE, BOB]);
 
         _handleOps(op); // does not revert: the op fails post-validation, EntryPoint logs it
 
-        // signer set untouched, nonce consumed
-        assertEq(vault.getSigner(0), createSigner(ALICE.addr));
-        assertEq(vault.getSigner(1), createSigner(BOB.addr));
-        assertEq(vault.getSignerCount(), 2);
+        // owner untouched, nonce consumed
+        assertEq(vault.owner(), CAROL.addr);
         assertEq(vault.getChainlessNonce(), 1);
     }
 

--- a/packages/smart-vaults/test/SmartVault.t.sol
+++ b/packages/smart-vaults/test/SmartVault.t.sol
@@ -90,6 +90,14 @@ contract SmartVaultTest is BaseTest {
         nft = new MockERC721();
     }
 
+    /// @dev Signer-state functions now require a chainless execution context; tests that exercise
+    ///      unrelated behavior seed the ctx slot directly (nonce 0, ROLE_THRESHOLD).
+    function _grantThresholdCtx() internal {
+        vm.store(
+            address(vault), 0xa376dc2f3bf9f2889ab135e26e6fcd0514f9576ec68e5f2a682d95ca957ade32, bytes32(uint256(1))
+        );
+    }
+
     function getUserOpHash(PackedUserOperation calldata userOp) internal view returns (bytes32) {
         return keccak256(abi.encode(userOp.hash(), ENTRY_POINT, block.chainid));
     }
@@ -172,7 +180,8 @@ contract SmartVaultTest is BaseTest {
 
     function getERC1271Signature(MultiSignerLib.SignatureWrapper[] memory sigs) internal pure returns (bytes memory) {
         SmartVault.ERC1271Signature memory sig = SmartVault.ERC1271Signature(sigs);
-        return abi.encode(sig);
+        // 0x00 = chain-bound domain discriminator
+        return abi.encodePacked(bytes1(0x00), abi.encode(sig));
     }
 
     function getUserOpSignature(
@@ -360,6 +369,7 @@ contract SmartVaultTest is BaseTest {
         userOp.signature = getUserOpSignature(getGasLimits(_userOp), sigs);
         userOp.paymasterAndData = new bytes(0);
 
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -457,6 +467,7 @@ contract SmartVaultTest is BaseTest {
     )
         public
     {
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -482,6 +493,7 @@ contract SmartVaultTest is BaseTest {
     {
         vm.deal(address(vault), _missingAccountsFund);
 
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -533,6 +545,7 @@ contract SmartVaultTest is BaseTest {
     )
         public
     {
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -562,6 +575,7 @@ contract SmartVaultTest is BaseTest {
     )
         public
     {
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -613,6 +627,7 @@ contract SmartVaultTest is BaseTest {
     )
         public
     {
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -641,6 +656,7 @@ contract SmartVaultTest is BaseTest {
     )
         public
     {
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -692,6 +708,7 @@ contract SmartVaultTest is BaseTest {
         userOp.signature = getUserOpSignature(getGasLimits(_userOp), sigs);
         userOp.paymasterAndData = new bytes(0);
 
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -728,6 +745,7 @@ contract SmartVaultTest is BaseTest {
         userOp.signature = getUserOpSignature(getGasLimits(_userOp), sigs);
         userOp.paymasterAndData = new bytes(0);
 
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -763,6 +781,7 @@ contract SmartVaultTest is BaseTest {
 
         userOp.signature = getUserOpSignature(getGasLimits(_userOp), sigs);
 
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -799,6 +818,7 @@ contract SmartVaultTest is BaseTest {
 
         userOp.signature = getUserOpSignature(getGasLimits(_userOp), sigs);
 
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -835,6 +855,7 @@ contract SmartVaultTest is BaseTest {
 
         userOp.signature = getUserOpSignature(getGasLimits(_userOp), sigs);
 
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -869,6 +890,7 @@ contract SmartVaultTest is BaseTest {
         userOp.signature = getUserOpSignature(getGasLimits(_userOp), sigs);
         userOp.paymasterAndData = new bytes(0);
 
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -905,6 +927,7 @@ contract SmartVaultTest is BaseTest {
         userOp.signature = getUserOpSignature(getGasLimits(userOp), sigs);
         userOp.paymasterAndData = new bytes(0);
 
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -986,6 +1009,7 @@ contract SmartVaultTest is BaseTest {
     )
         public
     {
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -1040,6 +1064,7 @@ contract SmartVaultTest is BaseTest {
     )
         public
     {
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -1085,6 +1110,7 @@ contract SmartVaultTest is BaseTest {
     {
         (uint256 maxPriorityFeePerGas, uint256 maxFeePerGas) = UserOperationLib.unpackUints(_userOp1.gasFees);
         vm.assume(uint128(maxPriorityFeePerGas) < type(uint128).max);
+        _grantThresholdCtx();
         vm.prank(address(vault));
         vault.updateThreshold(2);
 
@@ -1539,37 +1565,34 @@ contract SmartVaultTest is BaseTest {
     /*                               ONLY SELF TESTS                              */
     /* -------------------------------------------------------------------------- */
 
-    function test_onlySelf_addSigner() public {
+    /// @dev Signer-state updates through the plain execute path are now blocked: they require a
+    ///      chainless execution context so state stays in lockstep across chains.
+    function test_onlySelf_addSigner_revertsWithoutChainlessCtx() public {
         Caller.Call memory call = Caller.Call(
             address(vault), 0, abi.encodeWithSelector(MultiSignerAuth.addSigner.selector, createSigner(BOB.addr), 4)
         );
 
         vm.prank(ENTRY_POINT);
+        vm.expectRevert(SmartVault.InvalidChainlessContext.selector);
         vault.execute(call);
-
-        assertEq(vault.getSigner(4), createSigner(BOB.addr));
-        assertEq(vault.getSignerCount(), 4);
     }
 
-    function test_onlySelf_removeSigner() public {
+    function test_onlySelf_removeSigner_revertsWithoutChainlessCtx() public {
         Caller.Call memory call =
             Caller.Call(address(vault), 0, abi.encodeWithSelector(MultiSignerAuth.removeSigner.selector, 0));
 
         vm.prank(ENTRY_POINT);
+        vm.expectRevert(SmartVault.InvalidChainlessContext.selector);
         vault.execute(call);
-
-        assertEq(vault.getSigner(0), createSigner(address(0)));
-        assertEq(vault.getSignerCount(), 2);
     }
 
-    function test_onlySelf_updateThreshold() public {
+    function test_onlySelf_updateThreshold_revertsWithoutChainlessCtx() public {
         Caller.Call memory call =
             Caller.Call(address(vault), 0, abi.encodeWithSelector(MultiSignerAuth.updateThreshold.selector, 2));
 
         vm.prank(ENTRY_POINT);
+        vm.expectRevert(SmartVault.InvalidChainlessContext.selector);
         vault.execute(call);
-
-        assertEq(vault.getThreshold(), 2);
     }
 
     function test_onlySelf_upgradeImplementation_when_ownerIsZero() public {

--- a/packages/smart-vaults/test/mocks/MultiSignerMock.sol
+++ b/packages/smart-vaults/test/mocks/MultiSignerMock.sol
@@ -36,4 +36,6 @@ contract MultiSignerMock is MultiSignerAuth, Ownable {
     }
 
     function _authorize() internal view override(MultiSignerAuth) onlyOwner { }
+
+    function _checkChainlessRole(uint8) internal view override { }
 }


### PR DESCRIPTION
## What

Code spike for the **Chainless state update** item in the [SmartVault v1.1 spec](https://app.notion.com/p/splits/Spec-SmartVault-v1-1-15bf7c3c8eff80939bb3fcb03a14b4d0#3a4f7c3c8eff80a6a86aef8f3a6a8d0a): a new `ChainlessUserOp` signature type where one signature (threshold signers or owner) validates and executes a state update identically on every chain.

## Highlights

- Chain-stripped EIP-712 domain (`chainlessReplaySafeHash`) shared by the userOp and 1271 flows.
- Sequential vault-storage chainless nonce → lockstep state across chains
- Validation enforces zero gas price, no paymaster, and zero-value self-calls only
- `updateSignerSet`: atomic batch add/remove/threshold with invariants validated once at the end
- Role bitmask (THRESHOLD | OWNER) for signer-set functions; ownership actions OWNER-only

