### PR TITLE
PE-8418 Document PushSplit recipient-trust and transfer-failure edge cases

### DIFF
--- a/packages/splits-v2/docs/contracts.md
+++ b/packages/splits-v2/docs/contracts.md
@@ -34,13 +34,16 @@ Funds are deposited into the SplitsWarehouse and credited to each recipient as E
 ### Push Distribution (PushSplit)
 
 Funds are sent directly to each recipient via token transfers. For native ETH, if a direct transfer fails (e.g.,
-recipient is a contract that reverts), the amount is deposited to the warehouse as a fallback.
+recipient is a contract that reverts), the amount is deposited to the warehouse as a fallback. ERC20 transfers have no
+such fallback.
 
 **Tradeoffs:**
 
 - Simpler for few recipients (one-step process).
 - Higher gas cost per recipient (external transfers).
-- Can fail or behave unexpectedly if a recipient contract reverts on ERC20 transfers.
+- Distribution is atomic: a single recipient that reverts blocks payment to everyone. See
+  [Push vs Pull: Decision Guide](./integration-patterns.md#6-pull-vs-push-decision-guide) for recipient-trust and
+  recovery details.
 - Immediate delivery -- recipients do not need to claim.
 
 ---
@@ -144,7 +147,9 @@ source.
 ### [PushSplit](../src/splitters/push/PushSplit.sol)
 
 Split wallet that distributes funds directly to recipients (push model). Withdraws any warehouse balance first, then
-sends tokens via direct transfers. For native ETH, falls back to warehouse deposit if direct transfer fails.
+sends tokens via direct transfers. For native ETH, falls back to warehouse deposit if direct transfer fails; ERC20
+transfers have no fallback, so a single reverting recipient reverts the whole distribution. See
+[Push vs Pull: Decision Guide](./integration-patterns.md#6-pull-vs-push-decision-guide).
 
 **Key Functions:**
 

--- a/packages/splits-v2/docs/integration-patterns.md
+++ b/packages/splits-v2/docs/integration-patterns.md
@@ -131,8 +131,7 @@ token. Prefer PullSplit unless you specifically need direct sends.
 
 - ERC20 distribution is atomic: if `safeTransfer` to any recipient reverts, the entire `distribute()` reverts and no one
   is paid. Triggers include non-transferable tokens, recipient-side restrictions (e.g. a recipient added to the USDC
-  blacklist), and ERC-777 recipient hooks that revert.
-  A restriction can appear after the Split is created, outside anyone's control.
+  blacklist). A restriction can appear after the Split is created, outside anyone's control.
 - Native-token sends are gas-capped and fall back to a Warehouse deposit on failure, but the fallback is not itself
   failure-proof: a recipient that re-enters `distribute()` during its payout can leave the loop working from a stale
   balance snapshot, so the fallback deposit reverts and the distribution unwinds. Funds stay in the wallet,

--- a/packages/splits-v2/docs/integration-patterns.md
+++ b/packages/splits-v2/docs/integration-patterns.md
@@ -136,6 +136,9 @@ token. Prefer PullSplit unless you specifically need direct sends.
   failure-proof: a recipient that re-enters `distribute()` during its payout can leave the loop working from a stale
   balance snapshot, so the fallback deposit reverts and the distribution unwinds. Funds stay in the wallet,
   undistributed.
+- Recovery: an owned Split can drop the problem recipient via `updateSplit()` or sweep the balance via `execCalls()`
+  (both `onlyOwner`). An immutable Split (`owner == address(0)`) has no owner-based recovery and no
+  `depositToWarehouse()` escape hatch.
 
 **Integration checklist:**
 

--- a/packages/splits-v2/docs/integration-patterns.md
+++ b/packages/splits-v2/docs/integration-patterns.md
@@ -136,7 +136,7 @@ token. Prefer PullSplit unless you specifically need direct sends.
   failure-proof: a recipient that re-enters `distribute()` during its payout can leave the loop working from a stale
   balance snapshot, so the fallback deposit reverts and the distribution unwinds. Funds stay in the wallet,
   undistributed.
-- Recovery: an owned Split can drop the problem recipient via `updateSplit()` or sweep the balance via `execCalls()`
+- Recovery: a mutable Split can drop the problem recipient via `updateSplit()` or sweep the balance via `execCalls()`
   (both `onlyOwner`). An immutable Split (`owner == address(0)`) has no owner-based recovery and no
   `depositToWarehouse()` escape hatch.
 

--- a/packages/splits-v2/docs/integration-patterns.md
+++ b/packages/splits-v2/docs/integration-patterns.md
@@ -131,16 +131,12 @@ token. Prefer PullSplit unless you specifically need direct sends.
 
 - ERC20 distribution is atomic: if `safeTransfer` to any recipient reverts, the entire `distribute()` reverts and no one
   is paid. Triggers include non-transferable tokens, recipient-side restrictions (e.g. a recipient added to the USDC
-  blacklist -- USDT gates the sender, not the recipient, so it is unaffected), and ERC-777 recipient hooks that revert.
+  blacklist), and ERC-777 recipient hooks that revert.
   A restriction can appear after the Split is created, outside anyone's control.
 - Native-token sends are gas-capped and fall back to a Warehouse deposit on failure, but the fallback is not itself
   failure-proof: a recipient that re-enters `distribute()` during its payout can leave the loop working from a stale
   balance snapshot, so the fallback deposit reverts and the distribution unwinds. Funds stay in the wallet,
   undistributed.
-- Recovery: an owned Split can drop the problem recipient via `updateSplit()` or sweep the balance via `execCalls()`
-  (both `onlyOwner`, so `owner != address(0)` is required). An immutable Split has neither, and PushSplit has no
-  `depositToWarehouse()` escape hatch, so there is no owner-based recovery. PullSplit is unaffected -- it credits
-  warehouse balances and never transfers to recipients during distribution.
 
 **Integration checklist:**
 

--- a/packages/splits-v2/docs/integration-patterns.md
+++ b/packages/splits-v2/docs/integration-patterns.md
@@ -103,12 +103,13 @@ warehouse.setWithdrawConfig(ISplitsWarehouse.WithdrawConfig({
 | Gas cost per distribution   | Lower (internal balance transfers)                | Higher (external token transfers)                           |
 | Recipient count             | Better for many recipients                        | Better for few recipients                                   |
 | Recipient must claim?       | Yes (call warehouse.withdraw)                     | No (tokens arrive directly)                                 |
-| Risk of failed distribution | None (warehouse accounting)                       | Can fail if recipient reverts (ETH falls back to warehouse) |
+| Risk of failed distribution | None (warehouse accounting)                       | A single recipient that reverts blocks the whole distribution (see Security Considerations) |
 | Composability               | Recipients can use warehouse balances via ERC6909 | Standard token transfers                                    |
 | Best for                    | Protocols, DAOs, many-party splits                | Simple 2-3 party splits, EOA recipients                     |
 
 **Default recommendation:** Use PullSplit unless you have a specific reason to prefer push (e.g., simple 2-party split
-with EOA recipients).
+with EOA recipients). PushSplit requires trusting that every recipient can receive each distributed token; see Security
+Considerations below.
 
 ## 7. Security Considerations
 
@@ -122,6 +123,24 @@ with EOA recipients).
   pausing only blocks third parties.
 - Withdrawal pausing (`withdrawConfig.paused`) only blocks third-party withdrawals. The owner can always withdraw their
   own funds.
+
+**PushSplit recipient trust:**
+
+PushSplit pays recipients with direct token transfers, so every recipient must be able to receive each distributed
+token. Prefer PullSplit unless you specifically need direct sends.
+
+- ERC20 distribution is atomic: if `safeTransfer` to any recipient reverts, the entire `distribute()` reverts and no one
+  is paid. Triggers include non-transferable tokens, recipient-side restrictions (e.g. a recipient added to the USDC
+  blacklist -- USDT gates the sender, not the recipient, so it is unaffected), and ERC-777 recipient hooks that revert.
+  A restriction can appear after the Split is created, outside anyone's control.
+- Native-token sends are gas-capped and fall back to a Warehouse deposit on failure, but the fallback is not itself
+  failure-proof: a recipient that re-enters `distribute()` during its payout can leave the loop working from a stale
+  balance snapshot, so the fallback deposit reverts and the distribution unwinds. Funds stay in the wallet,
+  undistributed.
+- Recovery: an owned Split can drop the problem recipient via `updateSplit()` or sweep the balance via `execCalls()`
+  (both `onlyOwner`, so `owner != address(0)` is required). An immutable Split has neither, and PushSplit has no
+  `depositToWarehouse()` escape hatch, so there is no owner-based recovery. PullSplit is unaffected -- it credits
+  warehouse balances and never transfers to recipients during distribution.
 
 **Integration checklist:**
 


### PR DESCRIPTION
Makes PushSplit's recipient-trust assumptions and failure modes explicit in the splits-v2 docs.

- Push vs Pull decision guide + default recommendation now state the recipient-trust requirement.
- ERC20 distribution is atomic: if safeTransfer to any recipient reverts, the whole distribute() reverts. Triggers: non-transferable tokens, recipient-side restrictions (USDC blacklist; USDT gates the sender), ERC-777 reverting hooks.
- Native fallback is not failure-proof: a recipient re-entering distribute() can leave the loop on a stale balance snapshot, reverting the fallback deposit.
- Recovery: owned Splits use updateSplit()/execCalls() (onlyOwner); immutable Splits have no owner-based recovery and no depositToWarehouse() escape hatch. PullSplit is unaffected.
- contracts.md reference corrected to note ERC20 has no fallback.