### PR TITLE
docs(smart-vaults): document duplicate signer design decision

### DIFF
--- a/packages/smart-vaults/docs/contracts.md
+++ b/packages/smart-vaults/docs/contracts.md
@@ -56,8 +56,7 @@ Manages an m-of-n threshold signer set:
 **Signer uniqueness is not enforced onchain.** `initializeSigners`, `addSigner`, and the factory's `validateSigners`
 accept the same EOA or passkey at multiple indices. This is by design: the contract leaves signer-set configuration
 entirely to the owner. The consequence is that a key present at `k` indices can supply `k` of the `threshold`
-signatures, so duplicates lower the effective threshold. Integrators that want uniqueness must enforce it offchain. No
-change is planned for v1.1.
+signatures, so duplicates lower the effective threshold. Integrators that want uniqueness must enforce it offchain.
 
 Signature validation supports two modes:
 

--- a/packages/smart-vaults/docs/contracts.md
+++ b/packages/smart-vaults/docs/contracts.md
@@ -53,13 +53,19 @@ Manages an m-of-n threshold signer set:
 - Threshold cannot be zero and cannot exceed `signerCount`.
 - Removing a signer when `signerCount == threshold` reverts.
 
+**Signer uniqueness is not enforced onchain.** `initializeSigners`, `addSigner`, and the factory's `validateSigners`
+accept the same EOA or passkey at multiple indices. This is by design: the contract leaves signer-set configuration
+entirely to the owner. The consequence is that a key present at `k` indices can supply `k` of the `threshold`
+signatures, so duplicates lower the effective threshold. Integrators that want uniqueness must enforce it offchain. No
+change is planned for v1.1.
+
 Signature validation supports two modes:
 
 1. **Single-hash**: All signers verify the same hash (used for ERC-1271).
 2. **Front/back hash split**: First `threshold - 1` signers verify a "front hash" (light hash), final signer verifies
    the "back hash" (full userOp hash). This enables gas validation (see below).
 
-A bitmask prevents duplicate signers within a single validation.
+A bitmask prevents the same signer index from being used twice within a single validation (`DuplicateSigner`).
 
 ## UserOp Validation Flow
 


### PR DESCRIPTION
## Summary

- Records in `packages/smart-vaults/docs/contracts.md` that `MultiSignerLib` does not enforce signer uniqueness onchain: `initializeSigners`, `addSigner`, and the factory's `validateSigners` accept the same key at multiple indices, by design, leaving configuration to the owner.
- States the consequence (a key at `k` indices supplies `k` of `threshold` signatures) and that integrators must dedupe offchain.
- Rewords the validation bitmask sentence: it prevents reuse of a signer *index*, not a duplicate key.

Docs only, no contract or test changes.

Linear: [PE-8706](https://linear.app/splits/issue/PE-8706/add-duplicate-signer-design-decision-to-contract-docs)